### PR TITLE
Some minor CMakeLists.txt cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 option(LSL_UNIXFOLDERS "Use the unix folder layout for install targets" Off)
 option(LSL_NO_FANCY_LIBNAME "Skip library name decorations (32/64/-debug)")
 option(LSL_LEGACY_CPP_ABI "Build legacy C++ ABI" OFF)
-option(LSL_SO_LINKS_STDCPP_STATIC "On UNIX, the shared lib links std and libc statically." OFF)
 
 # lsl uses boost, but several other projects (e.g. Matlab) also use boost.
 # To prevent clashes with different boost versions, lsl ships a subset of
@@ -135,17 +134,10 @@ add_subdirectory(${LSL_LSLBOOST_PATH})
 
 # common definitions for the lsl and lsl-static
 function(lsllib_properties libname)
-	IF (UNIX AND LSL_SO_LINKS_STDCPP_STATIC)
-		target_link_libraries(${libname}
-			PRIVATE lslboost
-			PUBLIC -static-libgcc -static-libstdc++)
-	ELSEIF (MINGW)
-		target_link_libraries(${libname}
-			PRIVATE lslboost
-			PUBLIC ws2_32 wsock32 winmm)
-	ELSE()
-		target_link_libraries(${libname} PRIVATE lslboost)
-	ENDIF(UNIX AND LSL_SO_LINKS_STDCPP_STATIC)
+	target_link_libraries(${libname} PRIVATE lslboost)
+	if (MINGW)
+		target_link_libraries(${libname} PUBLIC ws2_32 wsock32 winmm)
+	endif()
 	target_include_directories(${libname}
 		INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,9 +135,6 @@ add_subdirectory(${LSL_LSLBOOST_PATH})
 # common definitions for the lsl and lsl-static
 function(lsllib_properties libname)
 	target_link_libraries(${libname} PRIVATE lslboost)
-	if (MINGW)
-		target_link_libraries(${libname} PUBLIC ws2_32 wsock32 winmm)
-	endif()
 	target_include_directories(${libname}
 		INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 	)

--- a/lslboost/CMakeLists.txt
+++ b/lslboost/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Platform-independent sources
-set(lslboost_sources
+add_library (lslboost STATIC
 	libs/atomic/src/lockpool.cpp
 	libs/chrono/src/chrono.cpp
 	libs/serialization/src/archive_exception.cpp
@@ -14,23 +14,24 @@ set(lslboost_sources
 	libs/serialization/src/void_cast.cpp
 )
 if (UNIX)
-	set(lslboost_sources_platform
+	target_sources(lslboost PRIVATE
 		libs/thread/src/pthread/once.cpp
 		libs/thread/src/pthread/thread.cpp
 	)
 	find_package(Threads REQUIRED)
-	set(Boost_LIBRARIES "Threads::Threads")
+	target_link_libraries(lslboost PRIVATE Threads::Threads)
 else ()  # WIN32
-	set(lslboost_sources_platform
+	target_sources(lslboost PRIVATE
 		libs/serialization/src/codecvt_null.cpp
 		libs/thread/src/win32/thread.cpp
 		libs/thread/src/win32/tss_dll.cpp
 		libs/thread/src/win32/tss_pe.cpp
 	)
-	set(Boost_LIBRARIES "")
+	if(MINGW)
+		target_link_libraries(lslboost PRIVATE wsock32 ws2_32 winmm)
+	endif()
 endif ()
 
-add_library (lslboost STATIC ${lslboost_sources} ${lslboost_sources_platform})
 target_compile_definitions(lslboost PUBLIC
 	BOOST_ALL_NO_LIB
 	BOOST_ASIO_ENABLE_OLD_SERVICES
@@ -43,7 +44,6 @@ target_compile_definitions(lslboost PUBLIC
 
 target_include_directories(lslboost SYSTEM PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-target_link_libraries(lslboost PRIVATE ${Boost_LIBRARIES})
 set_target_properties(lslboost PROPERTIES
 	CXX_VISIBILITY_PRESET hidden
 	POSITION_INDEPENDENT_CODE On


### PR DESCRIPTION
With the manylinux builds we pass the linker options via the command line so we don't need the build option any more (commit 1); link MinGW libraries to lslboost, not liblsl (commit 2; #14)