### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -1,0 +1,6 @@
+**/*
+!build/*.deb
+!build/**/*.tar.bz2
+!build/*.dmg
+!build/*.7z
+!build/*.so

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,27 @@
+trigger:
+- master
+jobs:
+- job: Linux
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - template: ci/azure_build_steps.yml
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - template: ci/azure_build_steps.yml
+    parameters:
+      cpack: false # cpack points to the wrong cpack
+- job: macOS
+  pool:
+    vmImage: 'macOS-10.14'
+  steps:
+  - template: ci/azure_build_steps.yml
+- job: manylinux
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: tktechdocker/manylinux:gcc8.3.0
+  steps:
+  - script: bash build_manylinux.sh
+    displayName: 'install prerequisites, build liblsl'

--- a/build_manylinux.sh
+++ b/build_manylinux.sh
@@ -6,8 +6,8 @@
 set -e -x
 
 # Install system packages required to build liblsl
-PATH=/opt/python/cp37-cp37m/bin:$PATH
-python -m pip install cmake ninja
+PATH=/opt/python/cp37-cp37m/bin:~/.local/bin/:$PATH
+python -m pip install --user cmake ninja
 
 mkdir -p build_manylinux && cd build_manylinux
 

--- a/ci/azure_build_steps.yml
+++ b/ci/azure_build_steps.yml
@@ -1,0 +1,23 @@
+parameters:
+  cpack: true
+  conda: false # doesn't work on macOS/Windows for some reason
+steps:
+- task: CMake@1
+  inputs:
+    cmakeArgs: '-DCMAKE_BUILD_TYPE=Release ..'
+  displayName: 'Configure build'
+- task: CMake@1
+  inputs:
+    cmakeArgs: '--build . --target install'
+  displayName: 'Build files'
+- ${{ if eq(parameters.conda, 'true') }}:
+  - task: CondaEnvironment@1
+    inputs:
+      packageSpecs: conda-build
+    displayName: set up anaconda
+  - bash: conda build $(Build.SourcesDirectory) --output-folder $(Build.ArtifactStagingDirectory)/conda
+    displayName: 'build conda package'
+- ${{ if eq(parameters.cpack, 'true') }}:
+  - bash: cpack
+    workingDirectory: 'build'
+    displayName: 'create cpack packages'


### PR DESCRIPTION
I set up a basic build for all three target platforms, anaconda on Linux and manylinux via docker on Azure Pipelines and so far I like it. It has a lot of rough edges concerning artifact deployment (no wildcards), cpack is broken on Windows and conda on Windows / macOS but sooner or later this'll work and we can get a nice badge.