### PR TITLE
Add  lsl-static to installed targets if LSL_BUILD_STATIC option is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,12 @@ endif()
 add_executable(lslver testing/lslver.c)
 target_link_libraries(lslver PRIVATE lsl)
 
-install(TARGETS lsl lslver
+set(EXPORTED_TARGETS lsl lslver)
+if(${LSL_BUILD_STATIC})
+	list(APPEND EXPORTED_TARGETS lslboost ${target}-static)
+endif()
+
+install(TARGETS ${EXPORTED_TARGETS}
 	COMPONENT liblsl
 	EXPORT "${PROJECT_NAME}Config"
 	RUNTIME DESTINATION ${LSLPREFIX}bin


### PR DESCRIPTION
I'm not sure if it makes sense to "install" a static library, but in my project I find useful to do:

```
find_package(LSL)
...
target_link_library(${TARGET_NAME} LSL::lsl-static
```

First time contributing, I hope I fulfill the requirements