### PR TITLE
Send multicast requests on all adapters

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -87,6 +87,7 @@ jobs:
               dpkg -I package/liblsl*.deb
            fi
            cmake -E remove_directory package/_CPack_Packages
+           cp testing/lslcfgs/default.cfg .
     - name: upload install dir
       uses: actions/upload-artifact@master
       with:

--- a/src/api_config.h
+++ b/src/api_config.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+namespace ip = asio::ip;
+
 namespace lsl {
 /**
  * A configuration object: holds all the configurable settings of liblsl.
@@ -83,7 +85,7 @@ public:
 	const std::string &resolve_scope() const { return resolve_scope_; }
 
 	/**
-	 * @brief List of multicast addresses on which inlets / outlets advertise/discover streams.
+	 * List of multicast addresses on which inlets / outlets advertise/discover streams.
 	 *
 	 * This is merged from several other config file entries
 	 * (LocalAddresses,SiteAddresses,OrganizationAddresses, GlobalAddresses)
@@ -98,7 +100,7 @@ public:
 	 * department) or organization (e.g., the campus), or at larger scope, multicast addresses
 	 * with the according scope need to be included.
 	 */
-	const std::vector<std::string> &multicast_addresses() const { return multicast_addresses_; }
+	const std::vector<ip::address> &multicast_addresses() const { return multicast_addresses_; }
 
 	/**
 	 * @brief The address of the local interface on which to listen to multicast traffic.
@@ -226,7 +228,7 @@ private:
 	bool allow_random_ports_;
 	uint16_t multicast_port_;
 	std::string resolve_scope_;
-	std::vector<std::string> multicast_addresses_;
+	std::vector<ip::address> multicast_addresses_;
 	int multicast_ttl_;
 	std::string listen_address_;
 	std::vector<std::string> known_peers_;

--- a/src/api_config.h
+++ b/src/api_config.h
@@ -1,7 +1,9 @@
 #ifndef API_CONFIG_H
 #define API_CONFIG_H
 
+#include "netinterfaces.h"
 #include <cstdint>
+#include <loguru.hpp>
 #include <string>
 #include <vector>
 
@@ -106,8 +108,16 @@ public:
 	const std::string &listen_address() const { return listen_address_; }
 
 	/**
-	 * @brief The TTL setting (time-to-live) for the multicast packets.
+	 * A list of local interface addresses the multicast packets should be
+	 * sent from.
 	 *
+	 * The ini file may contain IPv4 addresses and/or IPv6 addresses with the
+	 * interface index as scope id, e.g. `1234:5678::2%3`
+	 **/
+	std::vector<lsl::netif> multicast_interfaces;
+
+	/**
+	 * The TTL setting (time-to-live) for the multicast packets.
 	 * This is determined according to the ResolveScope setting if not overridden by the TTLOverride
 	 * setting. The higher this number (0-255), the broader their distribution. Routers (if
 	 * correctly configured) employ various thresholds below which packets are not further

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -26,7 +26,7 @@ resolver_impl::resolver_impl()
 	uint16_t mcast_port = cfg_->multicast_port();
 	for (const auto &mcast_addr : cfg_->multicast_addresses()) {
 		try {
-			mcast_endpoints_.emplace_back(asio::ip::make_address(mcast_addr), mcast_port);
+			mcast_endpoints_.emplace_back(mcast_addr, mcast_port);
 		} catch (std::exception &) {}
 	}
 

--- a/src/stream_outlet_impl.cpp
+++ b/src/stream_outlet_impl.cpp
@@ -79,16 +79,15 @@ void stream_outlet_impl::instantiate_stack(udp udp_protocol) {
 	// create UDP time server
 	udp_servers_.push_back(std::make_shared<udp_server>(info_, *io_ctx_service_, udp_protocol));
 	// create UDP multicast responders
-	for (const auto &mcastaddr : cfg->multicast_addresses()) {
+	for (const auto &address : cfg->multicast_addresses()) {
 		try {
 			// use only addresses for the protocol that we're supposed to use here
-			auto address = asio::ip::make_address(mcastaddr);
 			if (udp_protocol == udp::v4() ? address.is_v4() : address.is_v6())
 				responders_.push_back(std::make_shared<udp_server>(
-					info_, *io_ctx_service_, mcastaddr, multicast_port, multicast_ttl, listen_address));
+					info_, *io_ctx_service_, address, multicast_port, multicast_ttl, listen_address));
 		} catch (std::exception &e) {
-			LOG_F(WARNING, "Couldn't create multicast responder for %s (%s)", mcastaddr.c_str(),
-				e.what());
+			LOG_F(WARNING, "Couldn't create multicast responder for %s (%s)",
+				address.to_string().c_str(), e.what());
 		}
 	}
 }

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -1,4 +1,5 @@
 #include "udp_server.h"
+#include "api_config.h"
 #include "socket_utils.h"
 #include "stream_info_impl.h"
 #include "util/strfuns.hpp"
@@ -34,11 +35,10 @@ udp_server::udp_server(stream_info_impl_p info, asio::io_context &io, udp protoc
 		(void *)this);
 }
 
-udp_server::udp_server(stream_info_impl_p info, asio::io_context &io, const std::string &address,
+udp_server::udp_server(stream_info_impl_p info, asio::io_context &io, ip::address addr,
 	uint16_t port, int ttl, const std::string &listen_address)
 	: info_(std::move(info)), io_(io), socket_(std::make_shared<udp_socket>(io)),
 	  time_services_enabled_(false) {
-	ip::address addr = ip::make_address(address);
 	bool is_broadcast = addr == ip::address_v4::broadcast();
 
 	// set up the endpoint where we listen (note: this is not yet the multicast address)
@@ -65,16 +65,28 @@ udp_server::udp_server(stream_info_impl_p info, asio::io_context &io, const std:
 	// bind to the listen endpoint
 	socket_->bind(listen_endpoint);
 
-	// join the multicast group, if any
+	// join the multicast groups
 	if (addr.is_multicast() && !is_broadcast) {
-		if (addr.is_v4())
-			socket_->set_option(
-				ip::multicast::join_group(addr.to_v4(), listen_endpoint.address().to_v4()));
-		else
-			socket_->set_option(ip::multicast::join_group(addr));
+		bool joined_anywhere = false;
+		asio::error_code err;
+		for (auto &if_ : api_config::get_instance()->multicast_interfaces) {
+			DLOG_F(
+				INFO, "Joining %s to %s", if_.addr.to_string().c_str(), addr.to_string().c_str());
+			if (addr.is_v4() && if_.addr.is_v4())
+				socket_->set_option(ip::multicast::join_group(addr.to_v4(), if_.addr.to_v4()), err);
+			else if (addr.is_v6() && if_.addr.is_v6())
+				socket_->set_option(
+					ip::multicast::join_group(addr.to_v6(), if_.addr.to_v6().scope_id()), err);
+			if (err)
+				LOG_F(WARNING, "Could not bind multicast responder for %s to interface %s (%s)",
+					addr.to_string().c_str(), if_.addr.to_string().c_str(), err.message().c_str());
+			else
+				joined_anywhere = true;
+		}
+		if (!joined_anywhere) throw std::runtime_error("Could not join any multicast group");
 	}
 	LOG_F(2, "%s: Started multicast udp server at %s port %d (addr %p)",
-		this->info_->name().c_str(), address.c_str(), port, (void *)this);
+		this->info_->name().c_str(), addr.to_string().c_str(), port, (void *)this);
 }
 
 // === externally issued asynchronous commands ===

--- a/src/udp_server.h
+++ b/src/udp_server.h
@@ -46,7 +46,7 @@ public:
 	 * This server will listen on a multicast address and responds only to LSL:shortinfo requests.
 	 * This is for multicast/broadcast (and optionally unicast) local service discovery.
 	 */
-	udp_server(stream_info_impl_p info, asio::io_context &io, const std::string &address,
+	udp_server(stream_info_impl_p info, asio::io_context &io, asio::ip::address addr,
 		uint16_t port, int ttl, const std::string &listen_address);
 
 

--- a/src/util/cast.cpp
+++ b/src/util/cast.cpp
@@ -36,5 +36,6 @@ template signed char from_string(const std::string &);
 template char from_string(const std::string &);
 template int16_t from_string(const std::string &);
 template int32_t from_string(const std::string &);
+template uint32_t from_string(const std::string &);
 template int64_t from_string(const std::string &);
 } // namespace lsl

--- a/testing/lslcfgs/default.cfg
+++ b/testing/lslcfgs/default.cfg
@@ -1,2 +1,4 @@
+[ports]
+IPv6=allow
 [lab]
 KnownPeers=127.0.0.1

--- a/testing/lslcfgs/default.cfg
+++ b/testing/lslcfgs/default.cfg
@@ -2,3 +2,5 @@
 IPv6=allow
 [lab]
 KnownPeers=127.0.0.1
+[log]
+level=9

--- a/testing/lslcfgs/ipv4_lsl100.cfg
+++ b/testing/lslcfgs/ipv4_lsl100.cfg
@@ -4,3 +4,5 @@ IPv6=disable
 ResolveScope=link
 [tuning]
 use_protocol_version=100
+[log]
+level=9

--- a/testing/lslcfgs/ipv4only.cfg
+++ b/testing/lslcfgs/ipv4only.cfg
@@ -2,3 +2,5 @@
 IPv6=disable
 [multicast]
 ResolveScope=link
+[log]
+level=9

--- a/testing/lslcfgs/ipv6_lsl100.cfg
+++ b/testing/lslcfgs/ipv6_lsl100.cfg
@@ -4,3 +4,5 @@ IPv6=force
 ResolveScope=link
 [tuning]
 use_protocol_version=100
+[log]
+level=9

--- a/testing/lslcfgs/ipv6only.cfg
+++ b/testing/lslcfgs/ipv6only.cfg
@@ -2,3 +2,5 @@
 IPv6=force
 [multicast]
 ResolveScope=link
+[log]
+level=9


### PR DESCRIPTION
There have been some more bug reports with streams no / only one stream being found.

Currently, the "I'm looking for a stream"-multicast packets are only sent on one network adapter (on Linux it can be configured otherwise manually, but it ought to work out of the box).

So, this PR adds another config option for all local adapters multicast packets should be sent from, in case it's empty it's generated automatically (currently not yet working on Windows and not tested locally on macOS, but the previously failing CI is happy) and sends the multicast packets once for each configured adapter.