### PR TITLE
Add optional move support to C++ API types

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -2,11 +2,13 @@ name: C/C++ CI
 
 on:
   push:
-    branches:
-    - master
+    branches: ['*']
+    tags: ['*']
   pull_request:
-    branches:
-    - master
+  release:
+    types: ['created', 'edited']
+  create:
+    tags: ['*']
 
 jobs:
   build:
@@ -28,16 +30,27 @@ jobs:
            cmake --version
            cmake -E make_directory build
            cd build
-           cmake -DLSL_UNITTESTS=1 ..
+           cmake -DLSL_UNITTESTS=1 -DCPACK_PACKAGE_DIRECTORY=${PWD}/package ..
     - name: make
-      run: cmake --build build --config Release -j --target install
-      #    - name: pack everything up
-      #      shell: bash
-      #      run: cd build; mkdir upload; cpack -C Release -R $PWD/upload; rm -rf upload/_CPack_Packages/;
-    - uses: actions/upload-artifact@master
+      shell: bash
+      run: |
+           cmake --build build --config Release -j --target install
+           echo $GITHUB_REF
+           if [ $GITHUB_REF != "refs/heads"* ]; then
+             cmake --build build --config Release -j --target package
+             cmake -E remove_directory build/uploadpkgs/_CPack_Packages
+           fi
+    - name: upload install dir
+      uses: actions/upload-artifact@master
+      with:
+        name: build-${{ matrix.os }}
+        path: build/install
+    - name: upload package
+      uses: actions/upload-artifact@master
+      if: "!startsWith(github.ref, 'refs/heads')"
       with:
         name: pkg-${{ matrix.os }}
-        path: build/install
+        path: build/package
     - name: unit tests (internal functions)
       run: build/install/bin/lsl_test_internal --order rand --durations yes
     - name: unit tests (exported functions)

--- a/include/lsl_cpp.h
+++ b/include/lsl_cpp.h
@@ -285,9 +285,14 @@ namespace lsl {
         stream_info &operator=(const stream_info &rhs) { if (this != &rhs) obj = lsl_copy_streaminfo(rhs.obj); return *this; }
 
 #if  __cplusplus > 199711L || _MSC_VER>=1900
-		stream_info(stream_info&& rhs) noexcept {
-			this->obj = rhs.obj;
+		stream_info(stream_info&& rhs) noexcept : obj(rhs.obj) {
 			rhs.obj = nullptr;
+		}
+
+		stream_info& operator=(stream_info&& rhs) noexcept {
+			obj = rhs.obj;
+			rhs.obj = nullptr;
+			return *this;
 		}
 #endif
 
@@ -318,7 +323,6 @@ namespace lsl {
         *                     sampling rate, otherwise x100 in samples). The default is 6 minutes of data. 
         */
         stream_outlet(const stream_info &info, int32_t chunk_size=0, int32_t max_buffered=360): channel_count(info.channel_count()), obj(lsl_create_outlet(info.handle(),chunk_size,max_buffered)) {}
-
 
         // ========================================
         // === Pushing a sample into the outlet ===
@@ -596,14 +600,17 @@ namespace lsl {
 		~stream_outlet() { if(obj) lsl_destroy_outlet(obj); }
 
 #if __cplusplus > 199711L || _MSC_VER >= 1900
-		/** @brief stream_outlet Move constructor
-		 * @param rhs Outlet to move from. Using it afterwards will dereference
-		 * a null pointer and crash your application.
-		 */
-		stream_outlet(stream_outlet&& rhs) noexcept {
-			this->obj = rhs.obj;
+		/// stream_outlet move constructor
+		stream_outlet(stream_outlet &&res) noexcept
+			: channel_count(res.channel_count), obj(res.obj) {
+			res.obj = nullptr;
+		}
+
+		stream_outlet& operator=(stream_outlet&& rhs) noexcept {
+			channel_count = rhs.channel_count;
+			obj = rhs.obj;
 			rhs.obj = nullptr;
-			this->channel_count = rhs.channel_count;
+			return *this;
 		}
 #endif
 
@@ -708,7 +715,21 @@ namespace lsl {
         * Destructor.
         * The inlet will automatically disconnect if destroyed.
         */
-        ~stream_inlet() { lsl_destroy_inlet(obj); }
+        ~stream_inlet() { if(obj) lsl_destroy_inlet(obj); }
+
+#if __cplusplus > 199711L || _MSC_VER >= 1900
+		/// Move constructor for stream_inlet
+		stream_inlet(stream_inlet &&rhs) noexcept
+			: channel_count(rhs.channel_count), obj(rhs.obj) {
+			rhs.obj = nullptr;
+		}
+		stream_inlet &operator=(stream_inlet &&rhs) noexcept {
+			channel_count = rhs.channel_count;
+			obj = rhs.obj;
+			rhs.obj = nullptr;
+			return *this;
+		}
+#endif
 
         /** Retrieve the complete information of the given stream, including the extended description.
         * Can be invoked at any time of the stream's lifetime.
@@ -1245,7 +1266,20 @@ namespace lsl {
         /** 
         * Destructor.
         */
-        ~continuous_resolver() { lsl_destroy_continuous_resolver(obj); }
+        ~continuous_resolver() { if(obj) lsl_destroy_continuous_resolver(obj); }
+
+#if __cplusplus > 199711L || _MSC_VER >= 1900
+		/// Move constructor for stream_inlet
+		continuous_resolver(continuous_resolver &&rhs) noexcept : obj(rhs.obj) {
+			rhs.obj = nullptr;
+		}
+		continuous_resolver &operator=(continuous_resolver &&rhs) noexcept {
+			obj = rhs.obj;
+			rhs.obj = nullptr;
+			return *this;
+		}
+#endif
+
 
     private:
         lsl_continuous_resolver obj;

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -11,6 +11,7 @@ target_compile_features(catch_main PUBLIC cxx_std_11)
 add_executable(lsl_test_exported
 	DataType.cpp
 	discovery.cpp
+	move.cpp
 	timesync.cpp
 )
 target_link_libraries(lsl_test_exported PRIVATE lsl catch_main)

--- a/testing/helpers.h
+++ b/testing/helpers.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <lsl_cpp.h>
+
+struct Streampair {
+	lsl::stream_outlet out_;
+	lsl::stream_inlet in_;
+
+	Streampair(lsl::stream_outlet &&out, lsl::stream_inlet &&in)
+		: out_(std::move(out)), in_(std::move(in)) {}
+};
+
+static Streampair create_streampair(const lsl::stream_info &info) {
+	lsl::stream_outlet out(info);
+	auto found_stream_info(lsl::resolve_stream("name", info.name(), 1, 2.0));
+	if (found_stream_info.empty()) throw std::runtime_error("outlet not found");
+	lsl::stream_inlet in(found_stream_info[0]);
+
+	in.open_stream(2);
+	out.wait_for_consumers(2);
+	return Streampair(std::move(out), std::move(in));
+}

--- a/testing/move.cpp
+++ b/testing/move.cpp
@@ -1,0 +1,66 @@
+#include "catch.hpp"
+#include <lsl_cpp.h>
+#include <thread>
+
+namespace {
+
+TEST_CASE("move C++ API types", "[move][basic]") {
+	lsl::stream_info info("movetest", "test", 1, lsl::IRREGULAR_RATE, lsl::cf_int32);
+	lsl::stream_outlet outlet(info);
+	lsl::continuous_resolver resolver("name", "movetest");
+	auto found_stream_info = lsl::resolve_stream("name", "movetest", 1, 2.0);
+	REQUIRE(found_stream_info.size() == 1);
+	lsl::stream_inlet inlet(found_stream_info[0]);
+
+	inlet.open_stream(2);
+	outlet.wait_for_consumers(2);
+
+	int32_t data = 1;
+
+	{
+		// move the outlet via the move constructor
+		lsl::stream_outlet outlet2(std::move(outlet));
+		CHECK(outlet2.have_consumers());
+		outlet2.push_sample(&data);
+		// Move outlet2 back into outlet via the copy constructor
+		outlet = std::move(outlet2);
+		data++;
+		outlet.push_sample(&data);
+		// End of scope, destructor for outlet2 is called
+		// Since the stream_outlet is alive in outlet, it's not deconstructed
+	}
+
+	{
+		// move the outlet via the move constructor
+		lsl::stream_inlet inlet2(std::move(inlet));
+		REQUIRE(inlet2.get_channel_count() == 1);
+		inlet2.pull_sample(&data, 1);
+		CHECK(data == 1);
+		// Move inlet2 back into inlet via the copy constructor
+		inlet = std::move(inlet2);
+		inlet.pull_sample(&data, 1);
+		CHECK(data == 2);
+		// End of scope, destructor for outlet2 is called
+		// Since the stream_outlet is alive in outlet, it's not deconstructed
+	}
+
+	{
+		lsl::continuous_resolver resolver2(std::move(resolver));
+		resolver2.results();
+		resolver = std::move(resolver2);
+		resolver.results();
+	}
+
+	{
+		lsl::stream_outlet outlet3(std::move(outlet));
+		lsl::stream_inlet inlet3(std::move(inlet));
+		// End of scope, destructors for inlet3 and outlet3 are called
+	}
+
+	// Since the outlet has been destructed in the previous block, it shouldn't
+	// be there any more
+	found_stream_info = lsl::resolve_stream("name", "movetest", 1, 2.0);
+	REQUIRE(found_stream_info.empty());
+}
+
+}

--- a/testing/timesync.cpp
+++ b/testing/timesync.cpp
@@ -1,3 +1,4 @@
+#include "helpers.h"
 #include "catch.hpp"
 #include <lsl_cpp.h>
 #include <iostream>
@@ -5,16 +6,13 @@
 namespace {
 
 TEST_CASE("simple timesync", "[timesync][basic]") {
-	lsl::stream_outlet outlet(lsl::stream_info("timesync", "Test"));
-	auto si = lsl::resolve_stream("name", "timesync", 1, 2.0);
-	REQUIRE(si.size() == 1);
-	lsl::stream_inlet inlet(si[0]);
-	double offset = inlet.time_correction(5.) * 1000;
+	auto sp = create_streampair(lsl::stream_info("timesync", "Test"));
+	double offset = sp.in_.time_correction(5.) * 1000;
 	CHECK(offset < 1);
 	CAPTURE(offset);
 
 	double remote_time, uncertainty;
-	offset = inlet.time_correction(&remote_time, &uncertainty, 5.) * 1000;
+	offset = sp.in_.time_correction(&remote_time, &uncertainty, 5.) * 1000;
 	CHECK(offset < 1);
 	CHECK(uncertainty * 1000 < 1);
 	CHECK(remote_time < lsl::local_clock());


### PR DESCRIPTION
For compilers with enabled C++11 support, this adds move constructors to the header classes.
This allows passing objects to be passed into classes while ensuring that the underlying objects are deleted when they go out of scope.

Example:

``` cpp

struct Streampair {
	lsl::stream_outlet out_;
	lsl::stream_inlet in_;

	Streampair(lsl::stream_outlet &&out, lsl::stream_inlet &&in)
		: out_(std::move(out)), in_(std::move(in)) {}
};

static Streampair create_streampair(const lsl::stream_info &info) {
	lsl::stream_outlet out(info);
	auto found_stream_info(lsl::resolve_stream("name", info.name(), 1, 2.0));
	if (found_stream_info.empty()) throw std::runtime_error("outlet not found");
	lsl::stream_inlet in(found_stream_info[0]);

	in.open_stream(2);
	out.wait_for_consumers(2);
	return Streampair(std::move(out), std::move(in));
}
```

The second commit adds a unit test that checks both move constructor, assignment operators and destructors.