### PR TITLE
Update lsl_c.h

### DIFF
--- a/include/lsl_c.h
+++ b/include/lsl_c.h
@@ -134,7 +134,7 @@ typedef struct lsl_continuous_resolver_* lsl_continuous_resolver;
  * #endif
  * ```
  * */
-#define LIBLSL_COMPILE_HEADER_VERSION = 113;
+#define LIBLSL_COMPILE_HEADER_VERSION 113
 
 /**
  * Protocol version.


### PR DESCRIPTION
I tried to generate the go bindings using the swig definition files.
Swig complains about the line
#define LIBLSL_COMPILE_HEADER_VERSION = 113;

More
I get two errors using the swig compiler.  
This patch corrects the warning ../liblsl/include/lsl_c.h:137: Warning 305: Bad constant value (ignored).


ubuntu:~/liblsl-Generic$ swig -go -cgo  -intgosize 64 liblsl_c.i 
../liblsl/include/lsl_c.h:137: Warning 305: Bad constant value (ignored).
../liblsl/include/lsl_c.h:148: Error: Syntax error in input(1).