### PR TITLE
CMake: add LSLCMake functions to exported configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,19 +229,36 @@ endif()
 add_executable(lslver testing/lslver.c)
 target_link_libraries(lslver PRIVATE lsl)
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+	"${CMAKE_CURRENT_BINARY_DIR}/LSLConfigVersion.cmake"
+	VERSION "${liblsl_VERSION_MAJOR}.${liblsl_VERSION_MINOR}.${liblsl_VERSION_PATCH}"
+	COMPATIBILITY AnyNewerVersion
+)
+
 install(TARGETS ${LSL_EXPORT_TARGETS}
-	EXPORT LSLConfig 
+	EXPORT LSLTargets
 	COMPONENT liblsl
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(EXPORT LSLConfig  #"${PROJECT_NAME}Config"
+export(EXPORT LSLTargets
+	FILE "${CMAKE_CURRENT_BINARY_DIR}/LSLTargets.cmake"
+	NAMESPACE LSL::
+)
+
+install(EXPORT LSLTargets
+	FILE LSLTargets.cmake
 	COMPONENT liblsl
 	NAMESPACE "LSL::"
 	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/LSL
 )
+configure_file(cmake/LSLConfig.cmake "${CMAKE_CURRENT_BINARY_DIR}/LSLConfig.cmake" COPYONLY)
+configure_file(cmake/LSLCMake.cmake "${CMAKE_CURRENT_BINARY_DIR}/LSLCMake.cmake" COPYONLY)
+
 
 # install headers
 install(DIRECTORY include/
@@ -249,12 +266,12 @@ install(DIRECTORY include/
 	COMPONENT liblsl
 )
 
-install(FILES LSLCMake.cmake
+install(FILES cmake/LSLCMake.cmake ${CMAKE_CURRENT_BINARY_DIR}/LSLConfig.cmake
 	COMPONENT liblsl
 	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/LSL
 )
 
-include(LSLCMake.cmake)
+include(cmake/LSLCMake.cmake)
 
 if(LSL_UNITTESTS)
 	add_subdirectory(testing)

--- a/cmake/LSLCMake.cmake
+++ b/cmake/LSLCMake.cmake
@@ -1,6 +1,6 @@
 # Common functions and settings for LSL
 
-message(STATUS "Included LSL CMake helpers, rev. 11")
+message(STATUS "Included LSL CMake helpers, rev. 12, ${CMAKE_CURRENT_LIST_DIR}")
 option(LSL_DEPLOYAPPLIBS "Copy library dependencies (at the moment Qt + liblsl) to the installation dir" ON)
 
 # set build type and default install dir if not done already
@@ -13,21 +13,6 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH
 		"Where to put redistributable binaries" FORCE)
 	message(WARNING "CMAKE_INSTALL_PREFIX default initialized to ${CMAKE_INSTALL_PREFIX}")
-endif()
-
-# Try to find the labstreaminglayer library and enable
-# the imported target LSL::lsl
-#
-# Use it with
-# target_link_libraries(your_target_app PRIVATE LSL::lsl)
-
-if(TARGET lsl)
-	add_library(LSL::lsl ALIAS lsl)
-	message(STATUS "Found target lsl in current build tree")
-else()
-	message(STATUS "Trying to find package LSL")
-	list(APPEND CMAKE_PREFIX_PATH ${CMAKE_CURRENT_LIST_DIR})
-	find_package(LSL REQUIRED)
 endif()
 
 # Generate folders for IDE targets (e.g., VisualStudio solutions)

--- a/cmake/LSLConfig.cmake
+++ b/cmake/LSLConfig.cmake
@@ -1,0 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/LSLTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/LSLCMake.cmake")


### PR DESCRIPTION
For #47, put the exported targets into a separate cmake file that gets included alongside the `LSLCMake.cmake` helper functions by `find_package`.

Suggested usage in apps:

```
find_package(LSL 1.13.0 REQUIRED
	HINTS ${LSL_INSTALL_ROOT}
	"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/"
	"${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/install"
	PATH_SUFFIXES share/LSL
)
```

Tested:
- [X] in-tree builds (from an app dir)
- [X] in-tree builds (super-repo as root)
- [X] out-of-tree builds
- [X] from a cpack package
