### PR TITLE
Replace boost.bimap with std::unordered_map

### DIFF
--- a/src/stream_info_impl.h
+++ b/src/stream_info_impl.h
@@ -2,19 +2,26 @@
 #define STREAM_INFO_IMPL_H
 
 #include "common.h"
-#include <boost/bimap.hpp>
-#include <boost/thread/mutex.hpp>
 #include "pugixml/pugixml.hpp"
+#include <boost/thread/mutex.hpp>
+#include <unordered_map>
 
 namespace lsl {
+
+/// LRU cache for queries
+class query_cache {
+	std::unordered_map<std::string, int> cache;
+	int query_cache_age{0};
+	lslboost::mutex cache_mut_;
+public:
+	bool matches_query(const pugi::xml_document& doc, const std::string query, bool nocache);
+};
 
 	/**
 	* Actual implementation of the stream_info class.
 	* The stream_info class forwards all operations to an instance of this class.
 	*/
 	class stream_info_impl {
-		/// The query cache is a (bidirectional) mapping between query-strings and pairs of (last-use-timestamp, matching-true/false)
-		typedef lslboost::bimap<std::string,std::pair<double,bool> > query_cache;
 	public:
 
 		/**
@@ -80,7 +87,7 @@ namespace lsl {
 		* The info "matches" if the given XPath 1.0 query string returns a non-empty node set.
 		* @return Whether stream info is matched by the query string.
 		*/
-		bool matches_query(const std::string &query);
+		bool matches_query(const std::string &query, bool nocache = false);
 
 
 		//
@@ -255,7 +262,6 @@ namespace lsl {
 		pugi::xml_document doc_;
 		// cached query results
 		query_cache cached_;
-		lslboost::mutex cache_mut_;
 	};
 
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -5,10 +5,17 @@ project(lsltests
 	)
 cmake_minimum_required (VERSION 3.12)
 enable_testing()
+
+option(LSL_BENCHMARKS "Enable benchmarks in unit tests" OFF)
+
 add_library(catch_main OBJECT catch_main.cpp)
 target_compile_features(catch_main PUBLIC cxx_std_11)
 
 target_compile_definitions(catch_main PRIVATE LSL_VERSION_INFO=${LSL_VERSION_INFO})
+if(LSL_BENCHMARKS)
+	target_compile_definitions(catch_main PUBLIC CATCH_CONFIG_ENABLE_BENCHMARKING)
+endif()
+
 add_executable(lsl_test_exported
 	DataType.cpp
 	discovery.cpp
@@ -21,6 +28,7 @@ add_executable(lsl_test_internal
 	asiocancel.cpp
 	inireader.cpp
 	stringfuncs.cpp
+	streaminfo.cpp
 )
 target_link_libraries(lsl_test_internal PRIVATE lslobj lslboost catch_main)
 

--- a/testing/streaminfo.cpp
+++ b/testing/streaminfo.cpp
@@ -1,0 +1,52 @@
+#include "../src/stream_info_impl.h"
+#include "../src/api_config.h"
+#include "catch.hpp"
+
+TEST_CASE("streaminfo matching via XPath", "[basic][streaminfo][xml]") {
+	lsl::stream_info_impl info(
+		"streamname", "streamtype", 8, 500, lsl_channel_format_t::cft_string, "sourceid");
+	auto channels = info.desc().append_child("channels");
+	for(int i=0; i< 4;++i)
+		channels.append_child("channel").append_child("type").append_child(pugi::node_pcdata).set_value("EEG");
+	for(int i=0; i< 4;++i)
+		channels.append_child("channel").append_child("type").append_child(pugi::node_pcdata).set_value("EOG");
+
+#ifdef CATCH_CONFIG_ENABLE_BENCHMARKING
+	// Append lots of dummy channels for performance tests
+	for(int i=0; i<50000; ++i)
+		channels.append_child("chn").append_child("type").append_child(pugi::node_pcdata).set_value("foobar");
+	for(int i=0; i<2000; ++i) {
+		channels = channels.append_child("chn");
+		channels.append_child(pugi::node_pcdata).set_value("1");
+	}
+
+	BENCHMARK("trivial query") {
+		return info.matches_query("name='streamname' and type='streamtype'", true);
+	};
+	BENCHMARK("complicated query") {
+		return info.matches_query("count(desc/channels/channel[type='EEG'])>3", true);
+	};
+	BENCHMARK("Cached query") {
+		return info.matches_query("count(desc/channels/channel[type='EEG'])>3", false);
+	};
+
+	// test how well the cache copes with lots of different queries
+	BENCHMARK("partially cached queries (x1000)") {
+		int matches = 0;
+		for (int j = 0; j < 1000; ++j)
+			matches += info.matches_query(("0<=" + std::to_string(j)).c_str());
+		return matches;
+	};
+
+#endif
+
+	INFO(info.to_fullinfo_message());
+	REQUIRE(info.matches_query("name='streamname'"));
+	REQUIRE(info.matches_query("name='streamname' and type='streamtype'"));
+	REQUIRE(info.matches_query("channel_count > 5"));
+	REQUIRE(info.matches_query("nominal_srate >= 499"));
+	REQUIRE(info.matches_query("count(desc/channels/channel[type='EEG'])>3"));
+
+	REQUIRE(!info.matches_query("in'va'lid"));
+	REQUIRE(!info.matches_query("name='othername'"));
+}


### PR DESCRIPTION
Boost.bimap is a bit heavy for a query LRU cache, replacing it with a std::unordered map reduces peak compilation memory usage and debug symbol size by ~10%.

This also adds unit tests for (in-)valid XPath expressions and small optional benchmarks (`LSL_BENCHMARKS`).

Note about speed: a typical XPath expression on a huge XML stream info takes about 2us, a cached query lookup ~0.3us and 1000 cache lookups with automatic pruning of the cache about 2us.

```
trivial query                                             100            23     5.4878 ms 
                                                     2.463 us      2.427 us      2.522 us 
                                                       228 ns        154 ns        325 ns 
                                                                                          
complicated query                                         100             1    130.242 ms 
                                                   1.29732 ms    1.28074 ms    1.32216 ms 
                                                   101.818 us     76.011 us    165.859 us 
                                                                                          
Cached query                                              100           143     5.4054 ms 
                                                       311 ns        307 ns        318 ns 
                                                        25 ns         16 ns         38 ns 
                                                                                          
partially cached queries                                  100             1    190.131 ms 
                                                   1.92042 ms    1.90525 ms    1.94761 ms 
                                                   101.345 us     63.304 us    158.718 us 
```