### PR TITLE
Raise an error when attempting stream resolution with an malformed query

### DIFF
--- a/src/lsl_resolver_c.cpp
+++ b/src/lsl_resolver_c.cpp
@@ -86,13 +86,10 @@ LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_bypred(const
 */
 LIBLSL_C_API int32_t lsl_resolver_results(lsl_continuous_resolver res, lsl_streaminfo *buffer, uint32_t buffer_elements) {
 	try {
-		// query it
-		resolver_impl *resolver = res;
-		std::vector<stream_info_impl> tmp = resolver->results();
+		std::vector<stream_info_impl> tmp = res->results(buffer_elements);
 		// allocate new stream_info_impl's and assign to the buffer
-		uint32_t result = buffer_elements<tmp.size() ? buffer_elements : (uint32_t)tmp.size();
-		for (uint32_t k = 0; k < result; k++) buffer[k] = new stream_info_impl(tmp[k]);
-		return result;
+		for (uint32_t k = 0; k < tmp.size(); k++) buffer[k] = new stream_info_impl(tmp[k]);
+		return tmp.size();
 	} catch(std::exception &e) {
 		LOG_F(WARNING, "Unexpected error querying lsl_resolver_results: %s", e.what());
 		return lsl_internal_error;

--- a/src/lsl_resolver_c.cpp
+++ b/src/lsl_resolver_c.cpp
@@ -17,17 +17,7 @@ using namespace lsl;
 *					  The recommended default value is 5.0.
 */
 LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver(double forget_after) {
-	try {
-		// create a new resolver
-		resolver_impl *resolver = new resolver_impl();
-		// start it with the given query
-		std::ostringstream os; os << "session_id='" << api_config::get_instance()->session_id() << "'";
-		resolver->resolve_continuous(os.str(),forget_after);
-		return resolver;
-	} catch(std::exception &e) {
-		LOG_F(ERROR, "Error while creating a continuous_resolver: %s", e.what());
-		return nullptr;
-	}
+	return resolver_impl::create_resolver(forget_after);
 }
 
 /**
@@ -40,17 +30,7 @@ LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver(double forge
 *					  The recommended default value is 5.0.
 */
 LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_byprop(const char *prop, const char *value, double forget_after) {
-	try {
-		// create a new resolver
-		resolver_impl *resolver = new resolver_impl();
-		// start it with the given query
-		std::ostringstream os; os << "session_id='" << api_config::get_instance()->session_id() << "' and " << prop << "='" << value << "'";
-		resolver->resolve_continuous(os.str(),forget_after);
-		return resolver;
-	} catch(std::exception &e) {
-		LOG_F(ERROR, "Error while creating a continuous_resolver: %s", e.what());
-		return nullptr;
-	}
+	return resolver_impl::create_resolver(forget_after, prop, value);
 }
 
 /**
@@ -62,17 +42,7 @@ LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_byprop(const
 *					  The recommended default value is 5.0.
 */
 LIBLSL_C_API lsl_continuous_resolver lsl_create_continuous_resolver_bypred(const char *pred, double forget_after) {
-	try {
-		// create a new resolver
-		resolver_impl *resolver = new resolver_impl();
-		// start it with the given query
-		std::ostringstream os; os << "session_id='" << api_config::get_instance()->session_id() << "' and " << pred;
-		resolver->resolve_continuous(os.str(),forget_after);
-		return resolver;
-	} catch(std::exception &e) {
-		LOG_F(ERROR, "Error while creating a continuous_resolver: %s", e.what());
-		return nullptr;
-	}
+	return resolver_impl::create_resolver(forget_after, pred, nullptr);
 }
 
 /**
@@ -159,12 +129,8 @@ LIBLSL_C_API int32_t lsl_resolve_all(lsl_streaminfo *buffer, uint32_t buffer_ele
 */
 LIBLSL_C_API int32_t lsl_resolve_byprop(lsl_streaminfo *buffer, uint32_t buffer_elements, const char *prop, const char *value, int32_t minimum, double timeout) {
 	try {
-		// create a new resolver
-		resolver_impl resolver;
-		// build a new query.
-		std::ostringstream os; os << "session_id='" << api_config::get_instance()->session_id() << "' and " << prop << "='" << value << "'";
-		// invoke it
-		std::vector<stream_info_impl> tmp = resolver.resolve_oneshot(os.str(),minimum,timeout);
+		std::string query{resolver_impl::build_query(prop, value)};
+		auto tmp = resolver_impl().resolve_oneshot(query, minimum, timeout);
 		// allocate new stream_info_impl's and assign to the buffer
 		uint32_t result = buffer_elements<tmp.size() ? buffer_elements : (uint32_t)tmp.size();
 		for (uint32_t k = 0; k < result; k++) buffer[k] = new stream_info_impl(tmp[k]);
@@ -192,12 +158,8 @@ LIBLSL_C_API int32_t lsl_resolve_byprop(lsl_streaminfo *buffer, uint32_t buffer_
 */
 LIBLSL_C_API int32_t lsl_resolve_bypred(lsl_streaminfo *buffer, uint32_t buffer_elements, const char *pred, int32_t minimum, double timeout) {
 	try {
-		// create a new resolver
-		resolver_impl resolver;
-		// build a new query.
-		std::ostringstream os; os << "session_id='" << api_config::get_instance()->session_id() << "' and " << pred;
-		// invoke it
-		std::vector<stream_info_impl> tmp = resolver.resolve_oneshot(os.str(),minimum,timeout);
+		std::string query{resolver_impl::build_query(pred)};
+		auto tmp = resolver_impl().resolve_oneshot(query, minimum, timeout);
 		// allocate new stream_info_impl's and assign to the buffer
 		uint32_t result = buffer_elements<tmp.size() ? buffer_elements : (uint32_t)tmp.size();
 		for (uint32_t k = 0; k < result; k++) buffer[k] = new stream_info_impl(tmp[k]);

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -70,6 +70,28 @@ void check_query(const std::string& query) {
 	}
 }
 
+std::string resolver_impl::build_query(const char* pred_or_prop, const char* value)
+{
+	std::string query("session_id='");
+	query += api_config::get_instance()->session_id();
+	query += '\'';
+	if (pred_or_prop) (query += " and ") += pred_or_prop;
+	if (value) ((query += "='") += value) += '\'';
+	return query;
+}
+
+resolver_impl *resolver_impl::create_resolver(
+	double forget_after, const char *pred_or_prop, const char *value) noexcept {
+	try {
+		auto *resolver = new resolver_impl();
+		resolver->resolve_continuous(build_query(pred_or_prop, value), forget_after);
+		return resolver;
+	} catch (std::exception &e) {
+		LOG_F(ERROR, "Error while creating a continuous_resolver: %s", e.what());
+		return nullptr;
+	}
+}
+
 // === resolve functions ===
 
 /**

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -62,6 +62,13 @@ resolver_impl::resolver_impl()
 	}
 }
 
+void check_query(const std::string& query) {
+	try {
+		pugi::xpath_query(query.c_str());
+	} catch (std::exception &e) {
+		throw std::invalid_argument((("Invalid query '" + query) += "': ") += e.what());
+	}
+}
 
 // === resolve functions ===
 
@@ -70,6 +77,7 @@ resolver_impl::resolver_impl()
 * Blocks until at least the minimum number of streams has been resolved, or the timeout fires, or the resolve has been cancelled.
 */
 std::vector<stream_info_impl> resolver_impl::resolve_oneshot(const std::string &query, int minimum, double timeout, double minimum_time) {
+	check_query(query);
 	// reset the IO service & set up the query parameters
 	io_->restart();
 	query_ = query;
@@ -101,6 +109,7 @@ std::vector<stream_info_impl> resolver_impl::resolve_oneshot(const std::string &
 }
 
 void resolver_impl::resolve_continuous(const std::string &query, double forget_after) {
+	check_query(query);
 	// reset the IO service & set up the query parameters
 	io_->restart();
 	query_ = query;

--- a/src/resolver_impl.h
+++ b/src/resolver_impl.h
@@ -75,7 +75,7 @@ namespace lsl {
 		void resolve_continuous(const std::string &query, double forget_after=5.0);
 
 		/// Get the current set of results (e.g., during continuous operation).
-		std::vector<stream_info_impl> results();
+		std::vector<stream_info_impl> results(uint32_t max_results = 4294967295);
 
 		/// Tear down any ongoing operations and render the resolver unusable.
 		/// This can be used to cancel a blocking resolve_oneshot() from another thread (e.g., to initiate teardown of the object).

--- a/src/resolver_impl.h
+++ b/src/resolver_impl.h
@@ -44,6 +44,25 @@ namespace lsl {
 		*/
 		resolver_impl();
 
+		/** Build a query string
+		 *
+		 * @param pred_or_prop an entire predicate if value isn't set or the
+		 * name of the property, e.g. "foo='bar'" / "foo" (+value set as "bar")
+		 * @param value the value for the property parameter
+		 */
+		static std::string build_query(
+			const char *pred_or_prop = nullptr, const char *value = nullptr);
+
+		/** Create a resolver object with optionally a predicate or property + value
+		 *
+		 * @param pred_or_prop an entire predicate of value isn't set or the
+		 * name of the property, e.g. "foo='bar'" / "foo" (+value set as "bar")
+		 * @param value the value for the property parameter
+		 * @return A pointer to the resolver on success or nullptr on error
+		 */
+		static resolver_impl *create_resolver(double forget_after,
+			const char *pred_or_prop = nullptr, const char *value = nullptr) noexcept;
+
 		/// Destructor.
 		/// Cancels any ongoing processes and waits until they finish.
 		~resolver_impl();

--- a/testing/discovery.cpp
+++ b/testing/discovery.cpp
@@ -23,4 +23,8 @@ TEST_CASE("resolve from streaminfo", "[resolver][streaminfo][basic]") {
 	lsl::stream_inlet(outlet.info());
 }
 
+TEST_CASE("Invalid queries are caught before sending the query", "[resolver][streaminfo][basic]") {
+	REQUIRE_THROWS(lsl::resolve_stream("invalid'query", 0, 0.1));
+}
+
 } // namespace


### PR DESCRIPTION
At the moment, resolving streams with an invalid query silently fails (i.e. no streams are found).

This PR checks the query and throws an exception on failure before even sending the stream query packets.