### PR TITLE
Fix MacOS Qt deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,15 +201,12 @@ set_target_properties(lsl PROPERTIES
 	VERSION ${liblsl_VERSION_MAJOR}.${liblsl_VERSION_MINOR}.${liblsl_VERSION_PATCH}
 )
 
-set(LSL_EXPORT_TARGETS lsl lslobj lslboost lslver)
+set(LSL_EXPORT_TARGETS lsl lslobj lslboost)
 if(LSL_BUILD_STATIC)
 	add_library(lsl-static STATIC)
 	target_link_libraries(lsl-static PUBLIC lslobj PRIVATE lslboost)
 	# for LSL_CPP_API export header
 	target_compile_definitions(lsl-static INTERFACE LIBLSL_STATIC)
-	add_executable(lslver-static testing/lslver.c)
-	target_link_libraries(lslver-static PRIVATE lsl-static)
-	list(APPEND LSL_EXPORT_TARGETS lsl-static)
 endif()
 
 if(LSL_FORCE_FANCY_LIBNAME)
@@ -229,9 +226,6 @@ else()
 	set(CMAKE_INSTALL_INCLUDEDIR LSL/include)
 	set(CMAKE_INSTALL_DATAROOTDIR LSL/share)
 endif()
-
-add_executable(lslver testing/lslver.c)
-target_link_libraries(lslver PRIVATE lsl)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
@@ -279,6 +273,15 @@ install(FILES
 )
 
 include(cmake/LSLCMake.cmake)
+
+add_executable(lslver testing/lslver.c)
+target_link_libraries(lslver PRIVATE lsl)
+installLSLApp(lslver)
+if(LSL_BUILD_STATIC)
+	add_executable(lslver-static testing/lslver.c)
+	target_link_libraries(lslver-static PRIVATE lsl-static)
+	installLSLApp(lslver-static)
+endif()
 
 if(LSL_UNITTESTS)
 	add_subdirectory(testing)

--- a/cmake/LSLCMake.cmake
+++ b/cmake/LSLCMake.cmake
@@ -24,14 +24,6 @@ endif()
 # Generate folders for IDE targets (e.g., VisualStudio solutions)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-# Set runtime path, i.e. where shared libs are searched relative to the exe
-if(APPLE)
-	list(APPEND CMAKE_INSTALL_RPATH "@executable_path/../LSL/lib")
-	list(APPEND CMAKE_INSTALL_RPATH "@executable_path/../lib")
-	list(APPEND CMAKE_INSTALL_RPATH "@executable_path/")
-elseif(UNIX)
-	list(APPEND CMAKE_INSTALL_RPATH "\$ORIGIN/../LSL/lib:\$ORIGIN/../lib/:\$ORIGIN")
-endif()
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "limited configs" FORCE)
 
@@ -81,6 +73,17 @@ function(installLSLApp target)
 	# add start menu shortcut if supported by installer
 	set_property(INSTALL "${PROJECT_NAME}/$<TARGET_FILE_NAME:${target}>" PROPERTY
 		CPACK_START_MENU_SHORTCUTS "${target}")
+
+
+	# Set runtime path, i.e. where shared libs are searched relative to the exe
+	set(LIBDIRGENEXPR "../$<IF:$<BOOL:${LSL_UNIXFOLDERS}>,lib/,LSL/lib/>")
+	if(APPLE)
+		set_property(TARGET ${target} APPEND
+			PROPERTY INSTALL_RPATH "@executable_path/;@executable_path/${LIBDIRGENEXPR}")
+	elseif(UNIX)
+		set_property(TARGET ${target}
+			PROPERTY INSTALL_RPATH "\$ORIGIN:\$ORIGIN/${LIBDIRGENEXPR}")
+	endif()
 
 	if(LSL_UNIXFOLDERS)
 		include(GNUInstallDirs)


### PR DESCRIPTION
Calculate the MacOS bundle path only once, copy liblsl for Qt-apps, fix the macdeployqt call and show the output in case of an error.