### PR TITLE
fix compilation with LSL_DEBUGLOG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,12 @@ target_include_directories(lslboost PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lslboost>)
 
 
-target_link_libraries(lslobj PRIVATE lslboost)
+# one supplementary dependency for loguru
+if (LSL_DEBUGLOG)
+	target_link_libraries(lslobj PUBLIC ${CMAKE_DL_LIBS}  PRIVATE lslboost)
+else ()
+	target_link_libraries(lslobj PRIVATE lslboost)
+endif (LSL_DEBUGLOG)
 target_include_directories(lslobj
 	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 )


### PR DESCRIPTION
Hello,

I had to tune `CMakeLists.txt` in order to get liblsl compile when `LSL_DEBUGLOG` is enabled; otherwise I would get the following error:

```
[ 48%] Linking C executable lslver
liblsl.so.1.14.0: undefined reference to `dladdr'
collect2: error: ld returned 1 exit status
CMakeFiles/lslver.dir/build.make:84: recipe for target 'lslver' failed
make[2]: *** [lslver] Error 1
```

Indeed `liblsl/src/loguru/loguru.cpp` includes °<dlfcn.h>`.

Tested on Ubuntu 16.04, with cmake 3.12.0 and gcc 5.5.0.
