### PR TITLE
Build object target with XCode again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,13 @@ matrix:
   - os: osx
     osx_image: xcode10.1
     env: OSXVER=MacOS10.13
-  - os: osx
-    osx_image: xcode9.2
-    env: OSXVER=MacOS10.12
-  - os: osx
-    osx_image: xcode8
-    env: OSXVER=MacOS10.11
 before_script:
 - brew update
 - brew upgrade cmake
 script:
-- mkdir -p build/install
-- cd build
 - cmake --version
-- cmake -DCMAKE_BUILD_TYPE=Release -DLSL_UNIXFOLDERS=1 ${CMakeArgs} -DLSL_UNITTESTS=1 ../
+- cmake -S . -B build ${CMakeArgs} -DLSL_UNITTESTS=1
+- cd build
 - cmake --build . --config Release --target install
 - testing/lsl_test_internal || true
 - testing/lsl_test_exported

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(LSL_WINVER "0x0601" CACHE STRING
 	"Windows version (_WIN32_WINNT) to target (defaults to 0x0601 for Windows 7)")
 
 # Add an object library so all files are only compiled once
-set(lslobj_sources
+add_library(lslobj OBJECT
 	src/api_config.cpp
 	src/api_config.h
 	src/api_types.hpp
@@ -96,7 +96,6 @@ set(lslobj_sources
 	include/lsl/types.h
 	include/lsl/xml.h
 )
-add_library(lslobj OBJECT ${lslobj_sources})
 
 # try to find out which revision is currently checked out
 find_package(Git)
@@ -120,10 +119,8 @@ else()
 	set(lslgitrevision "unknown")
 	set(lslgitbranch "unknown")
 endif()
-set(LSL_VERSION_INFO "\"git:${lslgitrevision}/branch:${lslgitbranch}/build:${CMAKE_BUILD_TYPE}/compiler:${CMAKE_CXX_COMPILER_ID}-${CMAKE_CXX_COMPILER_VERSION}/boost:\" BOOST_LIB_VERSION")
-set_source_files_properties("src/common.cpp" PROPERTIES COMPILE_DEFINITIONS LSL_LIBRARY_INFO_STR=${LSL_VERSION_INFO})
+set(LSL_VERSION_INFO "git:${lslgitrevision}/branch:${lslgitbranch}/build:${CMAKE_BUILD_TYPE}/compiler:${CMAKE_CXX_COMPILER_ID}-${CMAKE_CXX_COMPILER_VERSION}")
 set_source_files_properties("src/loguru/loguru.cpp" PROPERTIES COMPILE_DEFINITIONS LOGURU_STACKTRACES=$<BOOL:${LSL_DEBUGLOG}>)
-
 
 ## create the lslboost target
 add_library(lslboost OBJECT
@@ -176,37 +173,24 @@ target_compile_definitions(lslobj
 )
 
 # shared library
-if (CMAKE_GENERATOR MATCHES "Xcode")
-    # Xcode is rather annoying in that it doesn't build SHARED libs unless they have source files.
-    # So we need to build from source, and then add all the other settings missing due to lack of lslobj
-    add_library(lsl SHARED ${lslobj_sources})
-    target_link_libraries(lsl PRIVATE lslboost)
-else()
-    add_library(lsl SHARED)
-    target_link_libraries(lsl
-		PUBLIC lslobj
-		PRIVATE lslboost)
-endif()
-target_include_directories(lsl
-	PUBLIC
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-		$<INSTALL_INTERFACE:include>
-)
-target_compile_definitions(lsl
-	PRIVATE LIBLSL_EXPORTS $<$<PLATFORM_ID:Windows>:_CRT_SECURE_NO_WARNINGS>
-	INTERFACE LSLNOAUTOLINK # don't use #pragma(lib) in CMake builds
-)
-
+add_library(lsl SHARED src/buildinfo.cpp)
+target_compile_definitions(lsl PRIVATE
+	LSL_LIBRARY_INFO_STR="${LSL_VERSION_INFO}/link:shared"
+	LIBLSL_EXPORTS)
+target_link_libraries(lsl
+	PUBLIC lslobj
+	PRIVATE lslboost)
 set_target_properties(lsl PROPERTIES
 	VERSION ${liblsl_VERSION_MAJOR}.${liblsl_VERSION_MINOR}.${liblsl_VERSION_PATCH}
 )
 
 set(LSL_EXPORT_TARGETS lsl lslobj lslboost)
 if(LSL_BUILD_STATIC)
-	add_library(lsl-static STATIC)
+	add_library(lsl-static STATIC src/buildinfo.cpp)
+	target_compile_definitions(lsl-static PRIVATE LSL_LIBRARY_INFO_STR="${LSL_VERSION_INFO}/link:static")
 	target_link_libraries(lsl-static PUBLIC lslobj PRIVATE lslboost)
 	# for LSL_CPP_API export header
-	target_compile_definitions(lsl-static INTERFACE LIBLSL_STATIC)
+	target_compile_definitions(lsl-static PUBLIC LIBLSL_STATIC)
 endif()
 
 if(LSL_FORCE_FANCY_LIBNAME)

--- a/include/lsl/common.h
+++ b/include/lsl/common.h
@@ -171,7 +171,7 @@ extern LIBLSL_C_API int32_t lsl_library_version();
  *
  * The format of the string shouldn't be used for anything important except giving a debugging
  * person a good idea which exact library version is used. */
-extern LIBLSL_C_API const char *lsl_library_info();
+extern LIBLSL_C_API const char *lsl_library_info(void);
 
 /**
  * Obtain a local system time stamp in seconds.

--- a/src/buildinfo.cpp
+++ b/src/buildinfo.cpp
@@ -1,0 +1,11 @@
+extern "C" {
+#include "../include/lsl/common.h"
+
+LIBLSL_C_API const char *lsl_library_info(void) {
+#ifdef LSL_LIBRARY_INFO_STR
+	return LSL_LIBRARY_INFO_STR;
+#else
+	return "Unknown (not set by build system)";
+#endif
+}
+}

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -20,14 +20,6 @@ LIBLSL_C_API int32_t lsl_protocol_version() {
 
 LIBLSL_C_API int32_t lsl_library_version() { return LSL_LIBRARY_VERSION; }
 
-LIBLSL_C_API const char *lsl_library_info() {
-#ifdef LSL_LIBRARY_INFO_STR
-	return LSL_LIBRARY_INFO_STR;
-#else
-	return "Unknown (not set by build system)";
-#endif
-}
-
 LIBLSL_C_API double lsl_local_clock() {
 	return lslboost::chrono::nanoseconds(
 			   lslboost::chrono::high_resolution_clock::now().time_since_epoch())

--- a/standalone_compilation_linux.sh
+++ b/standalone_compilation_linux.sh
@@ -5,7 +5,7 @@
 # For development, install a recent CMake version, either via pip
 # (pip install cmake) or as binary download from cmake.org
 
-set -x
+set -e -x
 # Try to read LSLGITREVISION from git if the variable isn't set
 echo ${LSLGITREVISION:="$(git describe --tags HEAD)"}
 ${CXX:-g++} -fPIC -fvisibility=hidden -O2 ${CFLAGS} -Ilslboost \

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -11,7 +11,7 @@ option(LSL_BENCHMARKS "Enable benchmarks in unit tests" OFF)
 add_library(catch_main OBJECT catch_main.cpp)
 target_compile_features(catch_main PUBLIC cxx_std_11)
 
-target_compile_definitions(catch_main PRIVATE LSL_VERSION_INFO=${LSL_VERSION_INFO})
+target_compile_definitions(catch_main PRIVATE LSL_VERSION_INFO="${LSL_VERSION_INFO}")
 if(LSL_BENCHMARKS)
 	target_compile_definitions(catch_main PUBLIC CATCH_CONFIG_ENABLE_BENCHMARKING)
 endif()

--- a/testing/catch_main.cpp
+++ b/testing/catch_main.cpp
@@ -8,7 +8,6 @@ int main(int argc, char *argv[]) {
 #endif
 	session.configData().runOrder = Catch::RunTests::InRandomOrder;
 #ifdef LSL_VERSION_INFO
-#define BOOST_LIB_VERSION ""
 	std::cout << "liblsl version: " << LSL_VERSION_INFO << '\n';
 #endif
 	int returnCode = session.applyCommandLine(argc, argv);


### PR DESCRIPTION
Add a separate source file with build information to the lsl and lsl-static targets so the XCode generator is happy again.