### PR TITLE
Lambda initializers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if (UNIX)
 	)
 	find_package(Threads REQUIRED)
 	target_link_libraries(lslboost PUBLIC Threads::Threads)
-	target_compile_features(lslboost PUBLIC cxx_std_11)
+	target_compile_features(lslboost PUBLIC cxx_std_11 cxx_lambda_init_captures)
 else ()  # WIN32
 	target_sources(lslboost PRIVATE
 		lslboost/libs/serialization/src/codecvt_null.cpp

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -136,8 +136,7 @@ void resolver_impl::resolve_continuous(const std::string &query, double forget_a
 	// start a wave of resolve packets
 	next_resolve_wave();
 	// spawn a thread that runs the IO operations
-	auto io_keepalive(io_);
-	background_io_ = std::make_shared<lslboost::thread>([io_keepalive]() { io_keepalive->run(); });
+	background_io_ = std::make_shared<lslboost::thread>([shared_io = io_]() { shared_io->run(); });
 }
 
 std::vector<stream_info_impl> resolver_impl::results(uint32_t max_results) {


### PR DESCRIPTION
Our oldest compiler (RHEL 5, GCC 4.7 for manylinux1) only has full support for C++11, but partial support for lambda initializers (e.g. `[shared_this = shared_from_this()]() { shared_this->do_cancel(); }`) so we should use it. Also avoid implicit `this` in closures when we have a `shared_ptr` pointing to the object.