### PR TITLE
Add lsl-static to exported targets if LSL_BUILD_STATIC option is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,12 +199,19 @@ if(LSL_BUILD_STATIC)
 endif()
 
 if(LSL_FORCE_FANCY_LIBNAME)
-	set(CMAKE_DEBUG_POSTFIX "-debug")
 	math(EXPR lslplatform "8 * ${CMAKE_SIZEOF_VOID_P}")
 	set_target_properties(lsl PROPERTIES
 		PREFIX ""
 		OUTPUT_NAME "liblsl${lslplatform}"
+		DEBUG_POSTFIX "-debug"
+	)
+	if(LSL_BUILD_STATIC)
+		set_target_properties(lsl-static PROPERTIES
+			PREFIX ""
+			OUTPUT_NAME "liblsl-static${lslplatform}"
+			DEBUG_POSTFIX "-debug"
 		)
+	endif()
 endif()
 
 if(LSL_UNIXFOLDERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ if(LSL_BUILD_STATIC)
 	target_link_libraries(lsl-static PUBLIC lslobj PRIVATE lslboost)
 	# for LSL_CPP_API export header
 	target_compile_definitions(lsl-static PUBLIC LIBLSL_STATIC)
+	list(APPEND LSL_EXPORT_TARGETS lsl-static)
 endif()
 
 if(LSL_FORCE_FANCY_LIBNAME)


### PR DESCRIPTION
Hello. I could not reopen #30. It's been a long time but I just noticed it's missing a small change to export the static library.