### PR TITLE
Improve error handling

### DIFF
--- a/include/lsl/common.h
+++ b/include/lsl/common.h
@@ -150,6 +150,8 @@ typedef enum {
 	_lsl_error_code_maxval = 0x7f000000
 } lsl_error_code_t;
 
+/// Return an explanation for the last error
+extern LIBLSL_C_API const char *lsl_last_error(void);
 
 /**
  * LSL version the binary was compiled against

--- a/include/lsl_cpp.h
+++ b/include/lsl_cpp.h
@@ -180,7 +180,9 @@ public:
 		double nominal_srate = IRREGULAR_RATE, channel_format_t channel_format = cf_float32,
 		const std::string &source_id = std::string())
 		: obj(lsl_create_streaminfo((name.c_str()), (type.c_str()), channel_count, nominal_srate,
-			  (lsl_channel_format_t)channel_format, (source_id.c_str()))) {}
+			  (lsl_channel_format_t)channel_format, (source_id.c_str()))) {
+		if (obj == nullptr) throw std::invalid_argument(lsl_last_error());
+	}
 	stream_info(lsl_streaminfo handle) : obj(handle) {}
 
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -12,7 +12,7 @@
 #pragma comment(lib, "winmm.lib")
 #endif
 
-char last_error[512];
+thread_local char last_error[512] = {0};
 
 extern "C" {
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -12,7 +12,10 @@
 #pragma comment(lib, "winmm.lib")
 #endif
 
+char last_error[512];
+
 extern "C" {
+
 LIBLSL_C_API int32_t lsl_protocol_version() {
 	return lsl::api_config::get_instance()->use_protocol_version();
 }
@@ -28,6 +31,8 @@ LIBLSL_C_API double lsl_local_clock() {
 LIBLSL_C_API void lsl_destroy_string(char *s) {
 	if (s) free(s);
 }
+
+LIBLSL_C_API const char *lsl_last_error(void) { return last_error; }
 }
 
 // === implementation of misc functions ===

--- a/src/common.h
+++ b/src/common.h
@@ -31,7 +31,7 @@ extern "C" {
 	"Please do not compile this with a lslboost version older than 1.45 because the library would otherwise not be protocol-compatible with builds using other versions."
 #endif
 
-extern char last_error[512];
+extern thread_local char last_error[512];
 
 // the highest supported protocol version
 // * 100 is the original version, supported by library versions 1.00+

--- a/src/common.h
+++ b/src/common.h
@@ -31,6 +31,8 @@ extern "C" {
 	"Please do not compile this with a lslboost version older than 1.45 because the library would otherwise not be protocol-compatible with builds using other versions."
 #endif
 
+extern char last_error[512];
+
 // the highest supported protocol version
 // * 100 is the original version, supported by library versions 1.00+
 // * 110 is an alternative protocol that improves throughput, supported by library versions 1.10+

--- a/src/lsl_c_api_helpers.hpp
+++ b/src/lsl_c_api_helpers.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "common.h"
+#include <cstdint>
+#include <cstring>
+
+/// Helper for LSL_STORE_EXCEPTION_IN
+#define LSLCATCHANDSTORE(ecvar, Exception, code)                                                   \
+	catch (Exception & e) {                                                                        \
+		strncpy(last_error, e.what(), sizeof(last_error) - 1);                                     \
+		int32_t *__ec = ecvar;                                                                     \
+		if (__ec != nullptr) *__ec = code;                                                         \
+	}
+
+/// Helper for LSL_STORE_EXCEPTION_IN
+#define LSLCATCHANDRETURN(Exception, code)                                                         \
+	catch (Exception & e) {                                                                        \
+		strncpy(last_error, e.what(), sizeof(last_error) - 1);                                     \
+		return code;                                                                               \
+	}
+
+
+/**
+ * C API exception helper.
+ *
+ * Inserts `catch()` statements for stl and liblsl exceptions and sets the
+ * variable pointed to by `ec` to the corresponding value from
+ * `lsl_error_code_t` and copies the error message to `last_error`.
+ *
+ * If you're trying to create a function `lsl_foobar_do_bar` that wraps the `FooBar`'s member
+ * function `do_bar`, this allows you to write
+ *
+ * ```
+ * function lsl_foobar_do_bar(lsl_foobar obj, int x, double y, int32_t *ec) {
+ *	try {
+ *		obj->do_bar(x, y);
+ *	} LSL_STORE_EXCEPTION_IN(ec)
+ * }
+ * ```
+ *
+ * instead of
+ *
+ * ```
+ * function lsl_foobar_do_bar(lsl_foobar obj, int x, double y, int32_t *ec) {
+ *	if(ec) *ec = lsl_no_error;
+ *	try {
+ *		return obj->do_bar(x, y);
+ *	}
+ *	catch(Ex1 &e) {
+ *		if(ec) *ec = lsl_error1;
+ *		strncpy(last_error, e.what(), sizeof(last_error-1);
+ *	}
+ *	catch(Ex2 &) {
+ *		if(ec) *ec = lsl_error2;
+ * 		strncpy(last_error, e.what(), sizeof(last_error-1);
+ *	}
+ *	// etc.
+ *	return 0;
+ * }
+ * ```
+ */
+#define LSL_STORE_EXCEPTION_IN(ecvar)                                                              \
+	LSLCATCHANDSTORE(ecvar, lsl::timeout_error, lsl_timeout_error)                                 \
+	LSLCATCHANDSTORE(ecvar, lsl::lost_error, lsl_lost_error)                                       \
+	LSLCATCHANDSTORE(ecvar, std::range_error, lsl_argument_error)                                  \
+	LSLCATCHANDSTORE(ecvar, std::invalid_argument, lsl_argument_error)                             \
+	LSLCATCHANDSTORE(ecvar, std::exception, lsl_internal_error)
+
+#define LSL_STORE_EXCEPTION LSL_STORE_EXCEPTION_IN(nullptr)
+
+/// Catch possible exceptions and return an appropriate error code or `lsl_no_error`
+#define LSL_RETURN_CAUGHT_EC                                                                       \
+	LSLCATCHANDRETURN(lsl::timeout_error, lsl_timeout_error)                                       \
+	LSLCATCHANDRETURN(lsl::lost_error, lsl_lost_error)                                             \
+	LSLCATCHANDRETURN(std::range_error, lsl_argument_error)                                        \
+	LSLCATCHANDRETURN(std::invalid_argument, lsl_argument_error)                                   \
+	LSLCATCHANDRETURN(std::exception, lsl_internal_error)                                          \
+	return lsl_no_error
+
+/// Try to create a new T object and return a pointer to it or `nullptr` if an exception occured.
+template <class Type, typename... T> Type *create_object_noexcept(T &&...args) noexcept {
+	try {
+		return new Type(std::forward<T>(args)...);
+	}
+	LSL_STORE_EXCEPTION_IN(nullptr)
+	return nullptr;
+}

--- a/src/lsl_outlet_c.cpp
+++ b/src/lsl_outlet_c.cpp
@@ -1,3 +1,4 @@
+#include "lsl_c_api_helpers.hpp"
 #include "stream_outlet_impl.h"
 
 #pragma warning(disable : 4800)
@@ -12,16 +13,8 @@ using namespace lsl;
 // boilerplate wrapper code
 LIBLSL_C_API lsl_outlet lsl_create_outlet(
 	lsl_streaminfo info, int32_t chunk_size, int32_t max_buffered) {
-	try {
-		stream_info_impl *infoimpl = info;
-		lsl_outlet result = new stream_outlet_impl(*infoimpl, chunk_size,
-			infoimpl->nominal_srate() ? (int)(infoimpl->nominal_srate() * max_buffered)
-									  : max_buffered * 100);
-		return result;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during construction of stream outlet: %s", e.what());
-		return nullptr;
-	}
+	return create_object_noexcept<stream_outlet_impl>(*info, chunk_size,
+		info->nominal_srate() ? (int)(info->nominal_srate() * max_buffered) : max_buffered * 100);
 }
 
 LIBLSL_C_API void lsl_destroy_outlet(lsl_outlet out) {
@@ -111,52 +104,18 @@ LIBLSL_C_API int32_t lsl_push_sample_ctp(
 }
 
 LIBLSL_C_API int32_t lsl_push_sample_v(lsl_outlet out, const void *data) {
-	try {
-		out->push_numeric_raw(data);
-		return lsl_no_error;
-	} catch (std::range_error &e) {
-		LOG_F(WARNING, "Error during push_sample: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::invalid_argument &e) {
-		LOG_F(WARNING, "Error during push_sample: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during push_sample: %s", e.what());
-		return lsl_internal_error;
-	}
+	return lsl_push_sample_vtp(out, data, 0.0, true);
 }
 
 LIBLSL_C_API int32_t lsl_push_sample_vt(lsl_outlet out, const void *data, double timestamp) {
-	try {
-		out->push_numeric_raw(data, timestamp);
-		return lsl_no_error;
-	} catch (std::range_error &e) {
-		LOG_F(WARNING, "Error during push_sample: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::invalid_argument &e) {
-		LOG_F(WARNING, "Error during push_sample: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during push_sample: %s", e.what());
-		return lsl_internal_error;
-	}
+	return lsl_push_sample_vtp(out, data, timestamp, true);
 }
 
 LIBLSL_C_API int32_t lsl_push_sample_vtp(
 	lsl_outlet out, const void *data, double timestamp, int32_t pushthrough) {
 	try {
 		out->push_numeric_raw(data, timestamp, pushthrough != 0);
-		return lsl_no_error;
-	} catch (std::range_error &e) {
-		LOG_F(WARNING, "Error during push_sample: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::invalid_argument &e) {
-		LOG_F(WARNING, "Error during push_sample: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during push_sample: %s", e.what());
-		return lsl_internal_error;
-	}
+	} LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API int32_t lsl_push_sample_str(lsl_outlet out, const char **data) {
@@ -371,17 +330,8 @@ LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data,
 		std::vector<std::string> tmp;
 		for (unsigned long k = 0; k < data_elements; k++) tmp.emplace_back(data[k]);
 		if (data_elements) out->push_chunk_multiplexed(&tmp[0], tmp.size(), timestamp, pushthrough);
-		return lsl_no_error;
-	} catch (std::range_error &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::invalid_argument &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during push_chunk: %s", e.what());
-		return lsl_internal_error;
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API int32_t lsl_push_chunk_strtn(
@@ -397,17 +347,8 @@ LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data,
 			for (unsigned long k = 0; k < data_elements; k++) tmp.emplace_back(data[k]);
 			out->push_chunk_multiplexed_noexcept(&tmp[0], timestamps, data_elements, pushthrough);
 		}
-		return lsl_no_error;
-	} catch (std::range_error &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::invalid_argument &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during push_chunk: %s", e.what());
-		return lsl_internal_error;
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API int32_t lsl_push_chunk_buf(
@@ -426,17 +367,8 @@ LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data,
 		std::vector<std::string> tmp;
 		for (unsigned long k = 0; k < data_elements; k++) tmp.emplace_back(data[k], lengths[k]);
 		if (data_elements) out->push_chunk_multiplexed(&tmp[0], tmp.size(), timestamp, pushthrough);
-		return lsl_no_error;
-	} catch (std::range_error &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::invalid_argument &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during push_chunk: %s", e.what());
-		return lsl_internal_error;
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data,
@@ -454,17 +386,8 @@ LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data,
 			out->push_chunk_multiplexed(
 				&tmp[0], timestamps, (std::size_t)data_elements, pushthrough);
 		}
-		return lsl_no_error;
-	} catch (std::range_error &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::invalid_argument &e) {
-		LOG_F(WARNING, "Error during push_chunk: %s", e.what());
-		return lsl_argument_error;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during push_chunk: %s", e.what());
-		return lsl_internal_error;
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API int32_t lsl_have_consumers(lsl_outlet out) {
@@ -486,11 +409,6 @@ LIBLSL_C_API int32_t lsl_wait_for_consumers(lsl_outlet out, double timeout) {
 }
 
 LIBLSL_C_API lsl_streaminfo lsl_get_info(lsl_outlet out) {
-	try {
-		return new stream_info_impl(out->info());
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error in lsl_get_info: %s", e.what());
-		return nullptr;
-	}
+	return create_object_noexcept<stream_info_impl>(out->info());
 }
 }

--- a/src/lsl_resolver_c.cpp
+++ b/src/lsl_resolver_c.cpp
@@ -1,4 +1,5 @@
 #include "api_config.h"
+#include "lsl_c_api_helpers.hpp"
 #include "resolver_impl.h"
 
 extern "C" {
@@ -29,10 +30,8 @@ LIBLSL_C_API int32_t lsl_resolver_results(
 		// allocate new stream_info_impl's and assign to the buffer
 		for (uint32_t k = 0; k < tmp.size(); k++) buffer[k] = new stream_info_impl(tmp[k]);
 		return static_cast<int32_t>(tmp.size());
-	} catch(std::exception &e) {
-		LOG_F(WARNING, "Unexpected error querying lsl_resolver_results: %s", e.what());
-		return lsl_internal_error;
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API void lsl_destroy_continuous_resolver(lsl_continuous_resolver res) {
@@ -55,11 +54,9 @@ LIBLSL_C_API int32_t lsl_resolve_all(
 		// allocate new stream_info_impl's and assign to the buffer
 		uint32_t result = buffer_elements < tmp.size() ? buffer_elements : (uint32_t)tmp.size();
 		for (uint32_t k = 0; k < result; k++) buffer[k] = new stream_info_impl(tmp[k]);
-		return result;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Error during resolve_all: %s", e.what());
-		return lsl_internal_error;
+		return static_cast<int32_t>(result);
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API int32_t lsl_resolve_byprop(lsl_streaminfo *buffer, uint32_t buffer_elements,
@@ -70,11 +67,9 @@ LIBLSL_C_API int32_t lsl_resolve_byprop(lsl_streaminfo *buffer, uint32_t buffer_
 		// allocate new stream_info_impl's and assign to the buffer
 		uint32_t result = buffer_elements < tmp.size() ? buffer_elements : (uint32_t)tmp.size();
 		for (uint32_t k = 0; k < result; k++) buffer[k] = new stream_info_impl(tmp[k]);
-		return result;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Error during resolve_byprop: %s", e.what());
-		return lsl_internal_error;
+		return static_cast<int32_t>(result);
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 
 LIBLSL_C_API int32_t lsl_resolve_bypred(lsl_streaminfo *buffer, uint32_t buffer_elements,
@@ -85,10 +80,8 @@ LIBLSL_C_API int32_t lsl_resolve_bypred(lsl_streaminfo *buffer, uint32_t buffer_
 		// allocate new stream_info_impl's and assign to the buffer
 		uint32_t result = buffer_elements < tmp.size() ? buffer_elements : (uint32_t)tmp.size();
 		for (uint32_t k = 0; k < result; k++) buffer[k] = new stream_info_impl(tmp[k]);
-		return result;
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Error during resolve_bypred: %s", e.what());
-		return lsl_internal_error;
+		return static_cast<int32_t>(result);
 	}
+	LSL_RETURN_CAUGHT_EC;
 }
 }

--- a/src/lsl_streaminfo_c.cpp
+++ b/src/lsl_streaminfo_c.cpp
@@ -1,3 +1,4 @@
+#include "lsl_c_api_helpers.hpp"
 #include "stream_info_impl.h"
 #include <cstring>
 #include <string>
@@ -13,23 +14,12 @@ using namespace lsl;
 LIBLSL_C_API lsl_streaminfo lsl_create_streaminfo(const char *name, const char *type,
 	int32_t channel_count, double nominal_srate, lsl_channel_format_t channel_format,
 	const char *source_id) {
-	try {
-		if (!source_id) source_id = "";
-		return new stream_info_impl(
-			name, type, channel_count, nominal_srate, channel_format, source_id);
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error during streaminfo construction: %s", e.what());
-		return nullptr;
-	}
+	return create_object_noexcept<stream_info_impl>(
+		name, type, channel_count, nominal_srate, channel_format, source_id);
 }
 
 LIBLSL_C_API lsl_streaminfo lsl_copy_streaminfo(lsl_streaminfo info) {
-	try {
-		return new stream_info_impl(*info);
-	} catch (std::exception &e) {
-		LOG_F(WARNING, "Unexpected error while copying a streaminfo: %s", e.what());
-		return nullptr;
-	}
+	return create_object_noexcept<stream_info_impl>(*info);
 }
 
 LIBLSL_C_API void lsl_destroy_streaminfo(lsl_streaminfo info) {

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(lsl_test_exported
 	test_ext_DataType.cpp
 	test_ext_discovery.cpp
 	test_ext_move.cpp
+	test_ext_streaminfo.cpp
 	test_ext_time.cpp
 )
 target_link_libraries(lsl_test_exported PRIVATE lsl catch_main)

--- a/testing/test_ext_streaminfo.cpp
+++ b/testing/test_ext_streaminfo.cpp
@@ -1,10 +1,27 @@
 #include "catch.hpp"
 #include <lsl_cpp.h>
+#include <thread>
 
 namespace {
 
 TEST_CASE("streaminfo", "[streaminfo][basic]") {
 	CHECK_THROWS(lsl::stream_info("", "emptyname"));
-	CHECK(std::string("The name of a stream must be non-empty.") == lsl_last_error());
+	REQUIRE(std::string("The name of a stream must be non-empty.") == lsl_last_error());
+}
+
+TEST_CASE("multithreaded lsl_last_error", "[threading][basic]") {
+	CHECK_THROWS(lsl::stream_info("", "emptyname"));
+	std::thread([](){
+		CHECK_THROWS(lsl::stream_info("hasname","type", -1));
+		REQUIRE(std::string("The channel_count of a stream must be nonnegative.") == lsl_last_error());
+	}).join();
+	REQUIRE(std::string("The name of a stream must be non-empty.") == lsl_last_error());
+}
+
+/// Ensure that an overly long error message won't overflow the buffer
+TEST_CASE("lsl_last_error size", "[basic]") {
+	std::string invalidquery(512, '\'');
+	CHECK_THROWS(lsl::resolve_stream(invalidquery, 1, 0.1));
+	REQUIRE(lsl_last_error()[512] == 0);
 }
 } // namespace

--- a/testing/test_ext_streaminfo.cpp
+++ b/testing/test_ext_streaminfo.cpp
@@ -1,0 +1,10 @@
+#include "catch.hpp"
+#include <lsl_cpp.h>
+
+namespace {
+
+TEST_CASE("streaminfo", "[streaminfo][basic]") {
+	CHECK_THROWS(lsl::stream_info("", "emptyname"));
+	CHECK(std::string("The name of a stream must be non-empty.") == lsl_last_error());
+}
+} // namespace


### PR DESCRIPTION
Let's take a simple example:

```
std::vector<std::string> formats = {"", "float32", "float64", "string", "int32", "int16", "int8", "int64"};
std::string format = "double64";
// convert the string to the format index
int fmt = std::distance(formats.begin(), std::find(formats.begin(), formats.end(), format);
try {
    lsl::stream_info info(streamname, "EEG", 1, 500, fmt);
} catch(..) { std::cout << "Error!" << std::endl; return; }
std::cout << info.created_at() << std::endl;
```

On a first glance, this should print the time the stream_info was created at.

On a second glance, the format is called `float64`, not `double64` so an exception should be thrown and the function should return.

In reality, a `lsl::stream_info` object is created, but the internal pointer is set to 0 so the call to `info.created_at()` will dereference a null pointer and everything will crash.

This PR first adds the helper macro `LSL_CATCH_EXCEPTIONS` and the helper function `create_object_noexcept` for the C-API to convert exceptions to error codes *and copy the error message to an internal variable*. The last error message can then be retrieved via the `lsl_last_error()` function.

After that, the C++ wrapper can check for errors (i.e. is the returned pointer valid) or throw an exception with the last error message.