### PR TITLE
Fixing flag to properly enable/disable loguru

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -42,7 +42,7 @@ void lsl::ensure_lsl_initialized() {
 		is_initialized = true;
 
 		loguru::g_stderr_verbosity = loguru::Verbosity_INFO;
-#ifdef LOGURU_DEBUG_LOGGING
+#if LOGURU_DEBUG_LOGGING
 		// Initialize loguru, mainly to print stacktraces on segmentation faults
 		int argc = 1;
 		const char *argv[] = {"liblsl", nullptr};


### PR DESCRIPTION
Hello,

Using python bindings I noticed that I could not properly set a custom handler for SIGINT due to LSL's Loguru catching all signals (e.g. "Loguru caught a signal: SIGINT"), bypassing any other handler. Part of the problem lies I think in how C/C++ code sometimes takes precedence over python during execution when it comes to signals; since there is a thread always executing some LSL code in the background once an inlet is created, I cannot gracefully exit my program when users hit Ctrl-C (among other use cases).

Anyway, I wanted to disable Loguru, and... I could not do it. It appears that the flag `LOGURU_DEBUG_LOGGING` used in `common.cpp` to init Loguru is always set. Indeed, in `loguru.hpp` there is this piece of code:

```
#ifndef LOGURU_DEBUG_LOGGING
	#ifndef NDEBUG
		#define LOGURU_DEBUG_LOGGING 1
	#else
		#define LOGURU_DEBUG_LOGGING 0
	#endif
#endif
```

Simple three letters fix: test if `LOGURU_DEBUG_LOGGING` is set to 1 rather than just defined. Now Loguru can be properly enabled or disabled, e.g. by setting `LSL_DEBUGLOG` to either 1 or 0 during compilation. Ok not *entirely* disabled (at least some logs appears from `api_config.cpp`), but enough to avoid catching signals.