### PR TITLE
Actions win32

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -20,19 +20,29 @@ jobs:
         - windows-latest
         - macOS-latest
       fail-fast: false
+    
     steps:
     - uses: actions/checkout@v1
+    
     - name: CMake version
       run: cmake --version
+    
     - name: Configure CMake
       shell: bash
       run: |
-           cmake --version
-           cmake -E make_directory build
-           cd build
-           cmake -DLSL_UNITTESTS=ON -DLSL_BUILD_EXAMPLES=ON -DCPACK_PACKAGE_DIRECTORY=${PWD}/package ..
+           cmake -S . -B build -T v140 -DLSL_UNITTESTS=ON -DLSL_BUILD_EXAMPLES=ON -DCPACK_PACKAGE_DIRECTORY=${PWD}/build/package ..
+    
+    - name: Configure CMake Win32
+      if: matrix.os == 'windows-latest'
+      run: cmake -S . -B build32 -T v140 -A Win32 -DLSL_UNITTESTS=ON -DLSL_BUILD_EXAMPLES=ON -DCPACK_PACKAGE_DIRECTORY=${PWD}/build32/package ..
+    
     - name: make
       run: cmake --build build --config Release -j --target install
+      
+    - name: make Win32
+      if: matrix.os == 'windows-latest'
+      run: cmake --build build32 --config Release -j --target install
+    
     - name: package
       shell: bash
       if: "!startsWith(github.ref, 'refs/heads')"
@@ -49,18 +59,28 @@ jobs:
               cmake --build build --config Release -j --target package
            fi
            cmake -E remove_directory build/uploadpkgs/_CPack_Packages
+           
+    - name: packate Win32
+      if: matrix.os == 'windows-latest'
+      run: cmake --build build32 --config Release -j --target package
+    
     - name: upload install dir
       uses: actions/upload-artifact@master
       with:
         name: build-${{ matrix.os }}
-        path: build/install
+        path: |
+            build/install
+            build32/install
 
     - name: upload package
       uses: actions/upload-artifact@master
       if: "!startsWith(github.ref, 'refs/heads')"
       with:
         name: pkg-${{ matrix.os }}
-        path: build/package
+        path: |
+            build/package
+            build32/package
+    
     - name: print network config
       shell: bash
       run: |
@@ -71,9 +91,11 @@ jobs:
               ip route
               ip -6 route
            fi
+    
     - name: unit tests (internal functions)
       run: build/install/bin/lsl_test_internal --order rand --wait-for-keypress never --durations yes
       timeout-minutes: 5
+    
     - name: unit tests (exported functions)
       shell: bash
       run: build/install/bin/lsl_test_exported --order rand --wait-for-keypress never --durations yes

--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -12,13 +12,15 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        os:
-        - ubuntu-latest
-        - windows-latest
-        - macOS-latest
+        config:
+          - {name: "ubuntu-latest", os: ubuntu-latest, cmake_extra: ""}
+          - {name: "windows-x64", os: windows-latest, cmake_extra: "-T v140"}
+          - {name: "windows-32", os: windows-latest, cmake_extra: "-T v140 -A Win32"}
+          - {name: "macOS-latest", os: macOS-latest, cmake_extra: ""}
       fail-fast: false
     
     steps:
@@ -30,19 +32,11 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
-           cmake -S . -B build -T v140 -DLSL_UNITTESTS=ON -DLSL_BUILD_EXAMPLES=ON -DCPACK_PACKAGE_DIRECTORY=${PWD}/build/package ..
-    
-    - name: Configure CMake Win32
-      if: matrix.os == 'windows-latest'
-      run: cmake -S . -B build32 -T v140 -A Win32 -DLSL_UNITTESTS=ON -DLSL_BUILD_EXAMPLES=ON -DCPACK_PACKAGE_DIRECTORY=${PWD}/build32/package ..
+           cmake -S . -B build ${{ matrix.config.cmake_extra }} -DLSL_UNITTESTS=ON -DLSL_BUILD_EXAMPLES=ON -DCPACK_PACKAGE_DIRECTORY=${PWD}/build/package ..
     
     - name: make
       run: cmake --build build --config Release -j --target install
       
-    - name: make Win32
-      if: matrix.os == 'windows-latest'
-      run: cmake --build build32 --config Release -j --target install
-    
     - name: package
       shell: bash
       if: "!startsWith(github.ref, 'refs/heads')"
@@ -53,33 +47,27 @@ jobs:
            # already installed packages. Therefore, we have built all
            # packages without dependencies in the previous step,
            # install them and rebuild them with dependency discovery enabled
-           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+           if [ "${{ matrix.config.os }}" = "ubuntu-latest" ]; then
               cmake -DCPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON .
               sudo dpkg -i build/package/*.deb
               cmake --build build --config Release -j --target package
            fi
            cmake -E remove_directory build/uploadpkgs/_CPack_Packages
            
-    - name: packate Win32
-      if: matrix.os == 'windows-latest'
-      run: cmake --build build32 --config Release -j --target package
-    
     - name: upload install dir
       uses: actions/upload-artifact@master
       with:
-        name: build-${{ matrix.os }}
+        name: build-${{ matrix.config.name }}
         path: |
             build/install
-            build32/install
 
     - name: upload package
       uses: actions/upload-artifact@master
       if: "!startsWith(github.ref, 'refs/heads')"
       with:
-        name: pkg-${{ matrix.os }}
+        name: pkg-${{ matrix.config.name }}
         path: |
             build/package
-            build32/package
     
     - name: print network config
       shell: bash


### PR DESCRIPTION
* Add Win32 builds to GitHub Actions
* Set v140 toolchain for Windows builds in GitHub Actions (better backwards compatibility)

This is a step towards simplifying the CI system.