### PR TITLE
Add missing windows dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,9 @@ target_link_libraries(lslboost
 	PRIVATE
 		$<$<PLATFORM_ID:Windows>:bcrypt>
 		$<$<PLATFORM_ID:Windows>:iphlpapi>
+		$<$<PLATFORM_ID:Windows>:winmm>
+		$<$<PLATFORM_ID:Windows>:mswsock>
+		$<$<PLATFORM_ID:Windows>:ws2_32>
 	)
 target_compile_features(lslboost PUBLIC cxx_std_11 cxx_lambda_init_captures)
 


### PR DESCRIPTION
The suggested patch makes the dependencies of LSL on the following windows DLLs explicit: winmm.dll, mwsock.dll, ws2_32.dll.

When compiling with Visual C++, these DLLs are used as well, as you can check with cygcheck or dependency-walker:
```
$ cygcheck.exe ./lsl.dll # DLL extracted from https://github.com/sccn/liblsl/releases/download/v1.14.0/liblsl-1.14.0-Win_amd64.zip
C:\liblslvc\bin\lsl.dll
  C:\Windows\system32\bcrypt.dll
    C:\Windows\system32\ntdll.dll
  C:\Windows\system32\KERNEL32.dll
    C:\Windows\system32\KERNELBASE.dll
  C:\Windows\system32\WINMM.dll
    C:\Windows\system32\msvcrt.dll
  C:\Windows\system32\WS2_32.dll
    C:\Windows\system32\RPCRT4.dll
  C:\Windows\system32\MSWSOCK.dll
```
Your default windows toolchain is Visual C++, and Visual C++ seems to figure out these dependencies automatically.

We are using liblsl compiled with MinGW-W64, and this toolchain cannot deduce this dependency automatically. We need the dependency explicitly specified, as in this patch.

Specifiying these dependencies automatically does not harm your build with Visual C++ - it will continue to work fine.

I ask you to apply this patch to your code base so that other users who also use MinGW will be able to use your library.