### PR TITLE
CI: Build against system pugixml on Ubuntu 20.04

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {name: "ubuntu-20.04", os: "ubuntu-20.04"}
+        - {name: "ubuntu-20.04", os: "ubuntu-20.04",   cmake_extra: "-DLSL_BUNDLED_PUGIXML=OFF"}
         - {name: "ubuntu-18.04", os: "ubuntu-18.04"}
         - {name: "ubuntu-16.04", os: "ubuntu-16.04"}
         - {name: "windows-x64",  os: "windows-latest", cmake_extra: "-T v140,host=x86"}
@@ -39,6 +39,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Configure CMake
       run: |
+           if [[ "${{ matrix.config.os }}" == "ubuntu-20.04" ]]; then
+                sudo apt-get install libpugixml-dev
+           fi
            cmake --version
            cmake -S . -B build \
                 -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Starting with Ubuntu 20.04, the `libpugixml-dev` package ships with a CMake config and if there's one thing distributors love it's packages not bundling everything they use. This builds require `libpugixml` to be installed, but the deb package lists it explicitely:

```
$ dpkg -I liblsl-1.14.0-focal_amd64.deb 
 neues Debian-Paket, Version 2.0.
 Architecture: amd64
 Depends: liblsl (= 1.14.0-focal), libc6 (>= 2.29), libgcc-s1 (>= 3.0), libpugixml1v5 (>= 1.6), libstdc++6 (>= 6)
 Description: Labstreaminglayer C/C++ library
```