### PR TITLE
Add github actions build file for MinGW-W64

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -15,11 +15,6 @@ on:
         required: false
         default: ''
 
-defaults:
-  run:
-    shell: bash
-
-
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -32,10 +27,17 @@ jobs:
         - {name: "ubuntu-18.04", os: "ubuntu-latest",  docker: "ubuntu:18.04" }
         - {name: "windows-x64",  os: "windows-latest", cmake_extra: "-T v140,host=x86"}
         - {name: "windows-32",   os: "windows-latest", cmake_extra: "-T v140,host=x86 -A Win32"}
+        - {name: "windows-mingw64", os: "windows-latest", cmake_extra: "-G 'MSYS Makefiles' -DLSL_OPTIMIZATIONS=OFF -DCMAKE_BUILD_TYPE=Debug"}
         - {name: "macOS-latest", os: "macOS-latest"}
     
     # runs all steps in the container configured in config.docker or as subprocesses when empty
     container: ${{ matrix.config.docker }}
+
+    # Use default bash for all targets except for MinGW
+    defaults:
+      run:
+        shell: ${{ matrix.config.name == 'windows-mingw64' && 'msys2 {0}' || 'bash' }}
+
     steps:
     - uses: actions/checkout@v2
     - name: set up build environment in container
@@ -44,7 +46,10 @@ jobs:
          apt install -y --no-install-recommends g++ git python3-pip ninja-build file dpkg-dev lsb-release sudo curl
          python3 -m pip install cmake
       if: ${{ matrix.config.docker }}
-
+    - uses: msys2/setup-msys2@v2
+      with:
+        release: false
+      if: ${{ matrix.config.name == 'windows-mingw64' }}
     - name: Configure CMake
       run: |
            if [[ "${{ matrix.config.os }}" == "ubuntu-20.04" ]]; then

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(Threads REQUIRED)
 
 add_executable(lsl_test_internal
 	test_int_inireader.cpp
+	test_int_loguruthreadnames.cpp
 	test_int_network.cpp
 	test_int_stringfuncs.cpp
 	test_int_streaminfo.cpp

--- a/testing/test_ext_streaminfo.cpp
+++ b/testing/test_ext_streaminfo.cpp
@@ -20,8 +20,8 @@ TEST_CASE("multithreaded lsl_last_error", "[threading][basic]") {
 
 /// Ensure that an overly long error message won't overflow the buffer
 TEST_CASE("lsl_last_error size", "[basic]") {
-	std::string invalidquery(512, '\'');
+	std::string invalidquery(511, '\'');
 	CHECK_THROWS(lsl::resolve_stream(invalidquery, 1, 0.1));
-	REQUIRE(lsl_last_error()[512] == 0);
+	REQUIRE(lsl_last_error()[511] == 0);
 }
 } // namespace

--- a/testing/test_int_loguruthreadnames.cpp
+++ b/testing/test_int_loguruthreadnames.cpp
@@ -1,0 +1,16 @@
+#include <loguru.hpp>
+#include <thread>
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("loguru_thread_local_storage", "[threading]") {
+	char name[2] = "0";
+	loguru::set_thread_name("1");
+	std::thread([&](){
+		loguru::set_thread_name("2");
+		loguru::get_thread_name(name,2,false);
+	}).join();
+	REQUIRE(name[0] == '2');
+	loguru::get_thread_name(name,2,false);
+	REQUIRE(name[0] == '1');
+}

--- a/thirdparty/loguru/loguru.cpp
+++ b/thirdparty/loguru/loguru.cpp
@@ -1023,7 +1023,7 @@ namespace loguru
 	// Where we store the custom thread name set by `set_thread_name`
 	char* thread_name_buffer()
 	{
-		__declspec( thread ) static char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
+		thread_local static char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
 		return &thread_name[0];
 	}
 #endif // LOGURU_WINTHREADS


### PR DESCRIPTION
FYI, this is how we build liblsl on windows for the MinGW compiler. As liblsl is a C++ library, users who write applications that use liblsl need to have their liblsl compiled with the same compiler as their application.

The build file is derived from your cross-platform build file. Compare against that file to find the differences. I was not sure how to integrate the different default shell settings required for this build (msys2) and all other platforms (bash) in github actions.

I have disabled examples and unit-tests because I get a linker error in one of them. I do not remember which, I remember that it is possible to fix the linker command manually quite easily, but I do not know enough cmake to fix it in the build system.

This pull request is mainly FYI. I for one would very much like if you accept it or merge into your cross-platform build file, but your priorities may lie elsewhere.