### PR TITLE
Header-only shim for Boost.Archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ option(LSL_LEGACY_CPP_ABI "Build legacy C++ ABI into lsl-static" OFF)
 option(LSL_OPTIMIZATIONS "Enable some more compiler optimizations" ON)
 option(LSL_UNITTESTS "Build LSL library unit tests" OFF)
 option(LSL_BUNDLED_PUGIXML "Use the bundled pugixml by default" ON)
+option(LSL_SLIMARCHIVE "Use experimental but smaller serialization code" OFF)
+
+mark_as_advanced(LSL_SLIMARCHIVE LSL_FORCE_FANCY_LIBNAME)
 
 set(LSL_WINVER "0x0601" CACHE STRING
 	"Windows version (_WIN32_WINNT) to target (defaults to 0x0601 for Windows 7)")
@@ -161,6 +164,11 @@ add_library(lslboost OBJECT
 	lslboost/serialization_objects.cpp
 )
 target_link_libraries(lslboost PUBLIC Threads::Threads)
+
+if(LSL_SLIMARCHIVE)
+	message(STATUS "Using shim instead of full Boost.Archive")
+	target_compile_definitions(lslboost PUBLIC SLIMARCHIVE)
+endif()
 target_compile_features(lslboost PUBLIC cxx_std_11 cxx_lambda_init_captures)
 
 target_compile_definitions(lslboost

--- a/lslboost/serialization_objects.cpp
+++ b/lslboost/serialization_objects.cpp
@@ -1,3 +1,5 @@
+// These implementation files aren't needed with slimarchive shim
+#ifndef SLIMARCHIVE
 #include "libs/serialization/src/archive_exception.cpp"
 #include "libs/serialization/src/basic_archive.cpp"
 #include "libs/serialization/src/basic_iarchive.cpp"
@@ -10,4 +12,5 @@
 #include "libs/serialization/src/void_cast.cpp"
 #ifdef _WIN32
 #include "libs/serialization/src/codecvt_null.cpp"
+#endif
 #endif

--- a/src/portable_archive/portable_archive_exception.hpp
+++ b/src/portable_archive/portable_archive_exception.hpp
@@ -14,8 +14,12 @@
 
 #pragma once
 
+#ifdef SLIMARCHIVE
+#include "slimarchive.hpp"
+#else
 #include <boost/archive/basic_archive.hpp>
 #include <boost/archive/archive_exception.hpp>
+#endif
 
 namespace eos {
 

--- a/src/portable_archive/portable_iarchive.hpp
+++ b/src/portable_archive/portable_iarchive.hpp
@@ -3,10 +3,14 @@
 #include <istream>
 #include "portable_archive_includes.hpp"
 
+#ifdef SLIMARCHIVE
+#include "slimarchive.hpp"
+#else
 #include <boost/archive/basic_binary_iprimitive.hpp>
 #include <boost/archive/basic_binary_iarchive.hpp>
 
 #include <boost/archive/detail/polymorphic_iarchive_route.hpp>
+#endif
 
 
 namespace eos {

--- a/src/portable_archive/portable_oarchive.hpp
+++ b/src/portable_archive/portable_oarchive.hpp
@@ -3,8 +3,12 @@
 #include <ostream>
 #include "portable_archive_includes.hpp"
 
+#ifdef SLIMARCHIVE
+#include "slimarchive.hpp"
+#else
 #include <boost/archive/basic_binary_oprimitive.hpp>
 #include <boost/archive/basic_binary_oarchive.hpp>
+#endif
 
 
 namespace eos {

--- a/src/portable_archive/slimarchive.hpp
+++ b/src/portable_archive/slimarchive.hpp
@@ -1,0 +1,193 @@
+#pragma once
+
+/// Small shim implementing the needed Boost serialization classes for liblsl
+
+#include <cstdint>
+#include <stdexcept>
+#include <streambuf>
+#include <type_traits>
+
+/// dummy #defines to prevent portable archive from loading additional boost archive parts
+#define NO_EXPLICIT_TEMPLATE_INSTANTIATION
+#define BOOST_ARCHIVE_SERIALIZER_INCLUDED
+#define BOOST_SERIALIZATION_REGISTER_ARCHIVE(typename)
+
+// forward declaration
+namespace lsl {
+class sample;
+}
+
+/// Maps LSL types to an index without needing full RTTI
+template <typename T> struct lsl_type_index {};
+template <> struct lsl_type_index<lsl::sample> { static const int idx = 0; };
+/// two classes used in unit tests
+template <> struct lsl_type_index<struct Testclass> { static const int idx = 1; };
+template <> struct lsl_type_index<struct Testclass2> { static const int idx = 2; };
+
+/// keep track of classes already seen once, needed for a field in Boost.Archive
+class serialized_class_tracker {
+	bool seen_[3]{false};
+
+public:
+	/// Return true /if an instance of this class has already been (de)serialized before
+	template <typename T> inline bool already_seen(const T &) {
+		if (seen_[lsl_type_index<T>::idx]) return true;
+		seen_[lsl_type_index<T>::idx] = true;
+		return false;
+	}
+};
+
+namespace lslboost {
+#ifndef BOOST_INTEGER_HPP
+/// Maps a type size in bits to the corresponding uintXY_t type
+template <int Size> struct uint_t {};
+template <> struct uint_t<8> { using least = uint8_t; };
+template <> struct uint_t<16> { using least = uint16_t; };
+template <> struct uint_t<32> { using least = uint32_t; };
+template <> struct uint_t<64> { using least = uint64_t; };
+#endif
+
+namespace archive {
+using library_version_type = uint8_t;
+inline library_version_type BOOST_ARCHIVE_VERSION() { return 17; }
+enum flags { no_header = 1, no_codecvt = 2 };
+
+struct archive_exception : std::exception {
+	archive_exception(int) {}
+	enum errors { invalid_signature, unsupported_version, other_exception };
+};
+
+/// Common class to store flags
+class flagstore {
+	int flags_;
+
+public:
+	flagstore(int flags) : flags_(flags) {}
+	int get_flags() const { return flags_; }
+};
+
+template <typename Archive> struct basic_binary_oarchive : public flagstore {
+	basic_binary_oarchive(int flags_) : flagstore(flags_) {}
+};
+
+template <typename Archive> struct basic_binary_iarchive : public flagstore {
+	basic_binary_iarchive(int flags_) : flagstore(flags_) {}
+};
+
+/// Helper base class for calling methods of an descendant class, i.e. Archive::fn, not this->fn
+template <typename Archive> class archive_upcaster {
+public:
+	archive_upcaster() {
+		static_assert(
+			std::is_base_of<typename std::remove_reference<decltype(*this)>::type, Archive>::value,
+			"Archive must inherit from basic_binary_i/oprimitive");
+	}
+
+	/** Return a reference to the actual archive implementation instead of the base class
+	 *
+	 * This is needed for most operations to call Archive::fn, not basic_binary_primitive::fn */
+	inline Archive &archive_impl() { return *((Archive *)this); }
+};
+
+/*
+template<typename Archive> class basic_binary_primitive {
+	std::streambuf &sb;
+}*/
+
+template <typename Archive, typename CharT, typename OSTraits>
+class basic_binary_oprimitive : private serialized_class_tracker,
+								private archive_upcaster<Archive> {
+	std::streambuf &sb;
+
+	/// calls Archive::serialize instead of this->serialize()
+	template <typename T> Archive &delegate_save(const T &t) {
+		this->archive_impl().save(t);
+		return this->archive_impl();
+	}
+
+public:
+	basic_binary_oprimitive(std::streambuf &sbuf, int) : archive_upcaster<Archive>(), sb(sbuf) {}
+
+	template <typename T> void save_binary(const T *data, std::size_t bytes) {
+		sb.sputn(reinterpret_cast<const char *>(data), bytes);
+	}
+
+	template <typename T> void save(const T &t) { save_binary<T>(&t, sizeof(T)); }
+
+	void save(const std::string &s) {
+		delegate_save(s.size());
+		save_binary(s.data(), s.size());
+	}
+
+	template <typename T>
+	std::enable_if_t<std::is_arithmetic<T>::value, Archive &> operator<<(const T &t) {
+		return delegate_save(t);
+	}
+
+	Archive &operator<<(const std::string &t) { return delegate_save(t); }
+
+	/// calls the `serialize()` member function if it exists
+	template <typename T, void (T::*fn)(Archive &, uint32_t) const = &T::serialize>
+	Archive &operator<<(const T &t) {
+		if (!this->already_seen(t)) save<uint16_t>(0);
+		t.serialize(this->archive_impl(), 0);
+		return this->archive_impl();
+	}
+
+	template <typename T> Archive &operator&(const T &t) { return this->archive_impl() << t; }
+};
+
+
+template <class Archive, typename CharT, typename OSTraits>
+class basic_binary_iprimitive : private serialized_class_tracker,
+								private archive_upcaster<Archive> {
+	std::streambuf &sb;
+
+	template <typename T> Archive &delegate_load(T &t) {
+		this->archive_impl().load(t);
+		return this->archive_impl();
+	}
+
+public:
+	basic_binary_iprimitive(std::streambuf &sbuf, int) : archive_upcaster<Archive>(), sb(sbuf) {}
+
+	/// Load raw binary data from the stream
+	template <typename T> void load_binary(T *data, std::size_t bytes) {
+		sb.sgetn(reinterpret_cast<char *>(data), bytes);
+	}
+
+	template <typename T> void load(T &t) { load_binary<T>(&t, sizeof(T)); }
+
+	void load(std::string &s) {
+		std::size_t size;
+		delegate_load(size);
+		char *data = new char[size];
+		load_binary(data, size);
+		s.assign(data, size);
+		delete[] data;
+	}
+
+	Archive &operator>>(std::string &t) { return delegate_load(t); }
+
+	template <typename T>
+	std::enable_if_t<std::is_arithmetic<T>::value, Archive &> operator>>(T &t) {
+		return delegate_load(t);
+	}
+
+	/// calls the `serialize()` member function if it exists
+	template <typename T, void (T::*fn)(Archive &, uint32_t) = &T::serialize>
+	Archive &operator>>(T &t) {
+		if (!this->already_seen(t)) {
+			uint16_t dummy;
+			load(dummy);
+		}
+		t.serialize(this->archive_impl(), 0);
+		return this->archive_impl();
+	}
+
+	template <typename T> Archive &operator&(T &t) { return this->archive_impl() >> t; }
+
+	void set_library_version(int) {}
+};
+} // namespace archive
+} // namespace lslboost

--- a/testing/internal/serialization_v100.cpp
+++ b/testing/internal/serialization_v100.cpp
@@ -18,14 +18,13 @@ struct Testclass {
 	lsl::sample_p s1, s2;
 	char testchar{0};
 
-	template <typename Archive> void serialize(Archive &a, const uint32_t) {
+	template <typename Archive> void serialize_(Archive &a) {
 		a &testchar &testint &negativeint &testbigint &testdouble &teststr &*s1 &*s2;
 	}
-	template <typename Archive> void load(Archive &a, const uint32_t archive_version) {
-		serialize(a, archive_version);
-	}
-	template <typename Archive> void save(Archive &a, const uint32_t archive_version) const {
-		const_cast<Testclass *>(this)->serialize(a, archive_version);
+	void serialize(eos::portable_iarchive &a, uint32_t) { serialize_(a); }
+
+	void serialize(eos::portable_oarchive &a, uint32_t) const {
+		const_cast<Testclass *>(this)->serialize_(a);
 	}
 
 	Testclass() : s1(doublefac.new_sample(0.0, false)), s2(strfac.new_sample(0.0, false)) {}
@@ -41,13 +40,8 @@ struct Testclass {
 struct Testclass2 {
 	uint64_t i;
 
-	template <typename Archive> void serialize(Archive &a, const uint32_t) { a &i; }
-	template <typename Archive> void load(Archive &a, const uint32_t archive_version) {
-		serialize(a, archive_version);
-	}
-	template <typename Archive> void save(Archive &a, const uint32_t archive_version) const {
-		const_cast<Testclass2 *>(this)->serialize(a, archive_version);
-	}
+	void serialize(eos::portable_iarchive &a, uint32_t) { a &i; }
+	void serialize(eos::portable_oarchive &a, uint32_t) const { a &i; }
 };
 
 TEST_CASE("v100 protocol serialization", "[basic][serialization]") {
@@ -107,5 +101,3 @@ TEST_CASE("v100 protocol serialization", "[basic][serialization]") {
 		if (*in1.s2 != *out1.s2) FAIL("Sample 2 serialization mismatch");
 	} catch (std::exception &e) { FAIL(e.what()); }
 }
-
-TEST_CASE("read v100 protocol samples", "[basic][serialization]") {}


### PR DESCRIPTION
After replacing large parts of Boost with the C++11 stdlib, there are only (optionally) parts of Asio and Boost.Archive left to build for the boost subset we use, so I've created a single-header header-only shim that offers all of the needed functionality.

It reduces the (release) binary size by 3.4%, build times by ~5% and the dependency on separate Boost compilation units by 100%. I haven'tr tried it, but this could enable building against a system boost installation without name mangling.

Backwards compatibility is a big concern, so [the already existing unit test](https://github.com/sccn/liblsl/blob/master/testing/internal/serialization_v100.cpp) makes sure that both Boost.Archive and the shim here serialize test data and LSL samples with the test pattern to the exact same binary data and can deserialize it to the original data.

For now, it's opt-in, but once it's tested across several compilers and most importantly on a big endian machine it could be enabled by default some time in the future.