### PR TITLE
Change the C++11 clock source

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -14,6 +14,10 @@
 
 thread_local char last_error[512] = {0};
 
+int64_t lsl::lsl_local_clock_ns() {
+	return std::chrono::nanoseconds(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
 extern "C" {
 
 LIBLSL_C_API int32_t lsl_protocol_version() {
@@ -22,13 +26,9 @@ LIBLSL_C_API int32_t lsl_protocol_version() {
 
 LIBLSL_C_API int32_t lsl_library_version() { return LSL_LIBRARY_VERSION; }
 
-int64_t lsl_local_clock_ns() {
-	return std::chrono::nanoseconds(std::chrono::steady_clock::now().time_since_epoch()).count();
-}
-
 LIBLSL_C_API double lsl_local_clock() {
 	const auto ns_per_s = 1000000000;
-	const auto seconds_since_epoch = std::lldiv(lsl_local_clock_ns(), ns_per_s);
+	const auto seconds_since_epoch = std::lldiv(lsl::lsl_local_clock_ns(), ns_per_s);
 	/* For large timestamps, converting to double and then dividing by 1e9 loses precision
 	   because double has only 53 bits of precision.
 	   So we calculate everything we can as integer and only cast to double at the end */
@@ -43,7 +43,6 @@ LIBLSL_C_API const char *lsl_last_error(void) { return last_error; }
 }
 
 // === implementation of misc functions ===
-double lsl::lsl_clock() { return lsl_local_clock(); }
 
 void lsl::ensure_lsl_initialized() {
 	static bool is_initialized = false;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -7,6 +7,9 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#if defined _MSC_VER && _MSC_VER < 1900
+#error "MSVC 2013's std::chrono isn't supported. Please upgrade to VS2015 or later"
+#endif
 #include <windows.h>
 // include mmsystem.h after windows.h
 #include <mmsystem.h>

--- a/src/common.h
+++ b/src/common.h
@@ -51,8 +51,11 @@ const double DEDUCED_TIMESTAMP = -1.0;
 /// Constant to indicate that a stream has variable sampling rate.
 const double IRREGULAR_RATE = 0.0;
 
+/// Obtain a local system time stamp in nanoseconds.
+int64_t lsl_local_clock_ns();
+
 /// Obtain a local system time stamp in seconds.
-double lsl_clock();
+inline double lsl_clock() { return lsl_local_clock(); }
 
 /// Ensure that LSL is initialized.
 void ensure_lsl_initialized();

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -56,6 +56,7 @@ if(LSL_BENCHMARKS)
 		bench_int_sleep.cpp
 	)
 	target_link_libraries(lsl_bench_internal PRIVATE lslobj lslboost catch_main)
+	target_include_directories(lsl_test_internal PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../src/)
 	installLSLApp(lsl_bench_internal)
 endif()
 

--- a/testing/bench_int_sleep.cpp
+++ b/testing/bench_int_sleep.cpp
@@ -1,6 +1,12 @@
 #include <catch2/catch.hpp>
 #include <thread>
+#include "../src/common.h"
 
 TEST_CASE("sleep") {
 	BENCHMARK("sleep1ms") { std::this_thread::sleep_for(std::chrono::milliseconds(1)); };
+}
+
+TEST_CASE("read system clock"){
+	BENCHMARK("lsl_local_clock") { return lsl_local_clock(); };
+	BENCHMARK("lsl_local_clock_ns") { return lsl::lsl_local_clock_ns(); };
 }

--- a/testing/lslver.c
+++ b/testing/lslver.c
@@ -2,6 +2,6 @@
 #include <stdio.h>
 
 int main() {
-	printf("LSL version: %d\n%s\n", lsl_library_version(), lsl_library_info());
+	printf("LSL version: %d\n%s\n%f\n", lsl_library_version(), lsl_library_info(), lsl_local_clock());
 	return 0;
 }


### PR DESCRIPTION
Quoting from the docs for `std::chrono::high_resolution_clock`:

> The high_resolution_clock is not implemented consistently across different standard library implementations, and its use should be avoided. It is often just an alias for std::chrono::steady_clock or std::chrono::system_clock, but which one it is depends on the library or configuration. When it is a system_clock, it is not monotonic (e.g., the time can go backwards). For example, for gcc's libstdc++ it is system_clock, for MSVC it is steady_clock, and for clang's libc++ it depends on configuration. 

This PR switches the clock source to `std::chrono::steady_clock` and converts the timestamps to double in two steps to avoid a precision loss (`double` has 53 bits of precision, but nanoseconds since 1970 are already in beyond 2**60).