### PR TITLE
Add C++ API function to retrieve the opaque C API handles

### DIFF
--- a/include/lsl_cpp.h
+++ b/include/lsl_cpp.h
@@ -766,6 +766,11 @@ public:
 	 */
 	stream_info info() const { return stream_info(lsl_get_info(obj.get())); }
 
+	/// Return a shared pointer to pass to C-API functions that aren't wrapped yet
+	///
+	/// Example: @code lsl_push_chunk_buft(outlet.handle().get(), data, …); @endcode
+	std::shared_ptr<lsl_outlet_struct_> handle() { return obj; }
+
 	/** Destructor.
 	 * The stream will no longer be discoverable after destruction and all paired inlets will stop
 	 * delivering data.
@@ -898,6 +903,11 @@ public:
 		bool recover = true)
 		: channel_count(info.channel_count()),
 		  obj(lsl_create_inlet(info.handle().get(), max_buflen, max_chunklen, recover), &lsl_destroy_inlet) {}
+
+	/// Return a shared pointer to pass to C-API functions that aren't wrapped yet
+	///
+	/// Example: @code lsl_pull_sample_buf(inlet.handle().get(), buf, …); @endcode
+	std::shared_ptr<lsl_inlet_struct_> handle() { return obj; }
 
 	/// Move constructor for stream_inlet
 	stream_inlet(stream_inlet &&rhs) noexcept = default;


### PR DESCRIPTION
I recently had a situation where I had to push some non-zero terminated strings with known lengths to an outlet with a regular sampling rate, so I only had one timestamp.

The C API had `int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, double timestamp)`, but it wasn't wrapped in the C++ API and I didn't want to give up the niceties the C++ API offered.

This PR adds a function `raw_lsl_ptr` to both the stream outlet and inlet so the plain C API functions can be called without having to rewrite everything to use the C API.