### PR TITLE
CMake: Change CMake config install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,6 @@ else()
 	set(CMAKE_INSTALL_BINDIR LSL)
 	set(CMAKE_INSTALL_LIBDIR LSL)
 	set(CMAKE_INSTALL_INCLUDEDIR LSL/include)
-	set(CMAKE_INSTALL_DATAROOTDIR LSL/share)
 endif()
 
 include(CMakePackageConfigHelpers)
@@ -264,7 +263,7 @@ install(EXPORT LSLTargets
 	FILE LSLTargets.cmake
 	COMPONENT liblsl
 	NAMESPACE "LSL::"
-	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/LSL
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LSL
 )
 configure_file(cmake/LSLConfig.cmake "${CMAKE_CURRENT_BINARY_DIR}/LSLConfig.cmake" COPYONLY)
 configure_file(cmake/LSLCMake.cmake "${CMAKE_CURRENT_BINARY_DIR}/LSLCMake.cmake" COPYONLY)
@@ -281,7 +280,7 @@ install(FILES
 	${CMAKE_CURRENT_BINARY_DIR}/LSLConfig.cmake
 	${CMAKE_CURRENT_BINARY_DIR}/LSLConfigVersion.cmake
 	COMPONENT liblsl
-	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/LSL
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LSL
 )
 
 include(cmake/LSLCMake.cmake)


### PR DESCRIPTION
Inspired by https://github.com/xdf-modules/libxdf/pull/32.

Basically, the proposed installation of the CMake config in `lib/cmake/LSL` is better in almost any way:

1. it allows side-by-side installations of 32 and 64 bit libraries
2. it's a path search for by default in `find_package()` so no `PATH_SUFFIXES` is needed
3. it makes distribution maintainers like us :-)