### PR TITLE
C++ API: replace bare pointer with smart pointers.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 # Changes for liblsl 1.14
 
 * **change**: CMake doesn't set `CMAKE_INSTALL_PREFIX`and `CMAKE_BUILD_TYPE` by default unless `LSL_COMFY_DEFAULTS` is set (Tristan Stenner)
+* change: object handles in the C++ API use smart pointers internally.
+  The smart pointer to the object can be retrieved with the `handle()` function
+* **change**: The `stream_info` copy constructor creates a shallow copy.
+  Use `stream_info::clone()` for the previous behavior (deep copy).
 * fix: prevent race condition when two threads modify an overflowing buffer (https://github.com/sccn/liblsl/pull/71, Jérémy Frey)
 * fix: improve latency and CPU usage (https://github.com/sccn/liblsl/pull/71, Jérémy Frey)
 * fix: various build system fixces and improvments (Chadwick Boulay, Tristan Stenner)

--- a/testing/test_ext_move.cpp
+++ b/testing/test_ext_move.cpp
@@ -61,6 +61,12 @@ TEST_CASE("move C++ API types", "[move][basic]") {
 	// be there any more
 	found_stream_info = lsl::resolve_stream("name", "movetest", 1, 2.0);
 	REQUIRE(found_stream_info.empty());
+
+	// stream_info copies are cheap, for independent copies clone() has to be used
+	lsl::stream_info copy1(info), copy2(info), clone(info.clone());
+	copy1.desc().append_child("Dummy");
+	REQUIRE(copy2.desc().first_child().name() == std::string("Dummy"));
+	REQUIRE(clone.desc().first_child().empty());
 }
 
 } // namespace


### PR DESCRIPTION
As of now, each LSL C++ API class keeps a pointer to an opaque LSL object and calls a function (e.g. `lsl_destroy_outlet`) to deconstruct and deallocate the object in its own destructor.

This PR replaces the bare pointers with smart pointers so the compiler can keep track of the C API object lifetimes and generate copy and move constructors / assignment operators automatically.

Moreover, this makes it possible to pass the pointer to end users e.g. for calling C API functions and keep multiple copies of wrapper classes around:

``` cpp
std::shared_ptr<lsl::stream_outlet> raw_handle = stream_outlet(…).get_raw_handle();
// here, the stream outlet is already deconstructed, but the handle is still valid
lsl_push_foo(raw_handle.get());

auto outlet = stream_outlet(...);
auto outlet_copy = outlet;
outlet.push_chunk(...);
outlet_copy.push_chunk();
```

The only change in behaviour concerns `stream_info` objects, as the copy constructor previously performed a deep copy.
This is now accomplished by the `stream_info::clone()` method:

``` cpp
// stream_info copies are cheap, for independent copies clone() has to be used
lsl::stream_info info(...);
lsl::stream_info copy1(info), copy2(info), clone(info.clone());
copy1.desc().append_child("Dummy");
REQUIRE(copy2.desc().first_child().name() == std::string("Dummy"));
REQUIRE(clone.desc().first_child().empty());
```