### PR TITLE
Fix API config log verbosity

### DIFF
--- a/src/api_config.cpp
+++ b/src/api_config.cpp
@@ -78,7 +78,6 @@ void api_config::load_from_file(const std::string &filename) {
 		if (!filename.empty()) {
 			std::ifstream infile(filename);
 			if (infile.good()) {
-				LOG_F(INFO, "Loading configuration from %s", filename.c_str());
 				pt.load(infile);
 			}
 		}
@@ -222,6 +221,9 @@ void api_config::load_from_file(const std::string &filename) {
 		} else
 			loguru::g_stderr_verbosity = log_level;
 
+        // log config filename only after setting the verbosity level
+		LOG_F(INFO, "Configuration loaded from %s", filename.c_str());
+
 	} catch (std::exception &e) {
 		LOG_F(ERROR, "Error parsing config file '%s': '%s', rolling back to defaults",
 			filename.c_str(), e.what());
@@ -230,6 +232,7 @@ void api_config::load_from_file(const std::string &filename) {
 		// and rethrow
 		throw e;
 	}
+
 }
 
 static std::once_flag api_config_once_flag;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -43,7 +43,6 @@ void lsl::ensure_lsl_initialized() {
 	if (!is_initialized) {
 		is_initialized = true;
 
-		loguru::g_stderr_verbosity = loguru::Verbosity_INFO;
 #if LOGURU_DEBUG_LOGGING
 		// Initialize loguru, mainly to print stacktraces on segmentation faults
 		int argc = 1;


### PR DESCRIPTION
The loguru library was introduced in v1.14.0. This release offers the ability to set the logging verbosity level in the `lsl_api.cfg` file. Unfortunately, the `log.level` setting is currently overriden in `common.cpp`. This PR fixes the issue. 