### PR TITLE
Force max_buflen * srate to be at least 1

### DIFF
--- a/src/lsl_inlet_c.cpp
+++ b/src/lsl_inlet_c.cpp
@@ -11,7 +11,7 @@ using namespace lsl;
 LIBLSL_C_API lsl_inlet lsl_create_inlet(
 	lsl_streaminfo info, int32_t max_buflen, int32_t max_chunklen, int32_t recover) {
 	return create_object_noexcept<stream_inlet_impl>(*info,
-		info->nominal_srate() ? (int)(info->nominal_srate() * max_buflen) : max_buflen * 100,
+		(info->nominal_srate() ? (int)(info->nominal_srate() * max_buflen) : max_buflen * 100) + 1,
 		max_chunklen, recover != 0);
 }
 


### PR DESCRIPTION
(this is a dup of #121, rebased on master after some CI fixes)

Very low rate streams combined with smallish max_buflen will give a queue size that gets truncated to 0. The result was a stream that kept disconnecting (at least that's what the log said). Here we + 1 to round up.

For situations where 0 < (nominal_srate() * max_buflen) % 1 < 0.5 , this PR actually gives you a queue length that's longer and less accurate (by 1) than before the change. For the rest of the situations, this is now more accurate. In sum, this is arguably better because it errs on the more conservative side (larger queue).

I started off using std::max(1, {old result}), which is closest to preserving old behaviour and just catching this error case, but it's probably a bit heavy to `#include<algorithm>` for such a simple fix.