### PR TITLE
Move sample copying/conversion to sample.cpp, use template overloading

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -2,17 +2,72 @@
 #include "sample.h"
 #include "portable_archive/portable_iarchive.hpp"
 #include "portable_archive/portable_oarchive.hpp"
+#include "util/cast.hpp"
+#include <boost/endian/conversion.hpp>
 
 using namespace lsl;
+using lslboost::endian::endian_reverse_inplace;
 
 #ifdef _MSC_VER
 #pragma warning(suppress : 4291)
 #endif
 
-sample::~sample() noexcept{
-	if (format_ != cft_string) return;
-	for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; ++p)
-		p->~basic_string<char>();
+/// range-for helper class for `values()`
+template <typename T> class dataiter {
+	T *begin_, *end_;
+
+public:
+	dataiter(void *begin, std::size_t n) : begin_(reinterpret_cast<T *>(begin)), end_(begin_ + n) {}
+	dataiter(const void *begin, std::size_t n)
+		: begin_(reinterpret_cast<const T *>(begin)), end_(begin_ + n) {}
+
+	// called from `f(auto val: dataiter)`
+	T *begin() const noexcept { return begin_; }
+	T *end() const noexcept { return end_; }
+};
+
+/// range-for helper. Sample usage: `for(auto &val: samplevalues<int32_t>()) val = 2;`
+template <typename T> inline dataiter<T> samplevals(sample &s) noexcept {
+	return dataiter<T>(iterhelper(s), s.num_channels());
+}
+
+template <typename T> inline dataiter<const T> samplevals(const sample &s) noexcept {
+	return dataiter<const T>(iterhelper(s), s.num_channels());
+}
+
+/// Copy an array, converting between LSL types if needed
+template <typename T, typename U>
+inline void copyconvert_array(const T *src, U *dst, std::size_t n) noexcept {
+	for (const T *end = src + n; src < end;)
+		*dst++ = static_cast<U>(*src++); // NOLINT(bugprone-signed-char-misuse)
+}
+
+/// Copy an array, special case: source and destination have the same type
+template <typename T> inline void copyconvert_array(const T *src, T *dst, std::size_t n) noexcept {
+	memcpy(dst, src, n * sizeof(T));
+}
+
+/// Copy an array, special case: destination is a string array
+template <typename T> inline void copyconvert_array(const T *src, std::string *dst, std::size_t n) {
+	for (const T *end = src + n; src < end;) *dst++ = lsl::to_string(*src++);
+}
+
+/// Copy an array, special case: source is a string array
+template <typename U> inline void copyconvert_array(const std::string *src, U *dst, std::size_t n) {
+	for (const auto *end = src + n; src < end;) *dst++ = lsl::from_string<U>(*src++);
+}
+
+/// Copy an array, special case: both arrays are string arrays
+inline void copyconvert_array(const std::string *src, std::string *dst, std::size_t n) {
+	std::copy_n(src, n, dst);
+}
+
+template <typename T, typename U> void lsl::sample::conv_from(const U *src) {
+	copyconvert_array(src, reinterpret_cast<T *>(&data_), num_channels_);
+}
+
+template <typename T, typename U> void lsl::sample::conv_into(U *dst) {
+	copyconvert_array(reinterpret_cast<const T *>(&data_), dst, num_channels_);
 }
 
 void sample::operator delete(void *x) noexcept {
@@ -25,99 +80,72 @@ void sample::operator delete(void *x) noexcept {
 		delete[](char *) x;
 }
 
+/// ensure that a given value is a multiple of some base, round up if necessary
+constexpr uint32_t ensure_multiple(uint32_t v, unsigned base) {
+	return (v % base) ? v - (v % base) + base : v;
+}
+
+// Sample functions
+
+lsl::sample::~sample() noexcept {
+	if (format_ == cft_string)
+		for (auto &val : samplevals<std::string>(*this)) val.~basic_string<char>();
+}
+
 bool sample::operator==(const sample &rhs) const noexcept {
 	if ((timestamp != rhs.timestamp) || (format_ != rhs.format_) ||
 		(num_channels_ != rhs.num_channels_))
 		return false;
 	if (format_ != cft_string)
 		return memcmp(&(rhs.data_), &data_, datasize()) == 0;
-	else {
-		std::string *data = (std::string *)&data_;
-		std::string *rhsdata = (std::string *)&(rhs.data_);
-		for (std::size_t k = 0; k < num_channels_; k++)
-			if (data[k] != rhsdata[k]) return false;
-		return true;
+
+	// For string values, each value has to be compared individually
+	auto thisvals = samplevals<const std::string>(*this);
+	return std::equal(thisvals.begin(), thisvals.end(), samplevals<std::string>(rhs).begin());
+}
+
+template <class T> void lsl::sample::assign_typed(const T *src) {
+	switch (format_) {
+	case cft_float32: conv_from<float>(src); break;
+	case cft_double64: conv_from<double>(src); break;
+	case cft_int8: conv_from<int8_t>(src); break;
+	case cft_int16: conv_from<int16_t>(src); break;
+	case cft_int32: conv_from<int32_t>(src); break;
+#ifndef BOOST_NO_INT64_T
+	case cft_int64: conv_from<int64_t>(src); break;
+#endif
+	case cft_string: conv_from<std::string>(src); break;
+	default: throw std::invalid_argument("Unsupported channel format.");
 	}
 }
 
-sample &sample::assign_typed(const std::string *s) {
+template <class T> void lsl::sample::retrieve_typed(T *dst) {
 	switch (format_) {
-	case cft_string:
-		for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; *p++ = *s++)
-			;
-		break;
-	case cft_float32:
-		for (float *p = (float *)&data_, *e = p + num_channels_; p < e;
-			 *p++ = from_string<float>(*s++))
-			;
-		break;
-	case cft_double64:
-		for (double *p = (double *)&data_, *e = p + num_channels_; p < e;
-			 *p++ = from_string<double>(*s++))
-			;
-		break;
-	case cft_int8:
-		for (int8_t *p = (int8_t *)&data_, *e = p + num_channels_; p < e;
-			 *p++ = from_string<int8_t>(*s++))
-			;
-		break;
-	case cft_int16:
-		for (int16_t *p = (int16_t *)&data_, *e = p + num_channels_; p < e;
-			 *p++ = from_string<int16_t>(*s++))
-			;
-		break;
-	case cft_int32:
-		for (int32_t *p = (int32_t *)&data_, *e = p + num_channels_; p < e;
-			 *p++ = from_string<int32_t>(*s++))
-			;
-		break;
+	case cft_float32: conv_into<float>(dst); break;
+	case cft_double64: conv_into<double>(dst); break;
+	case cft_int8: conv_into<int8_t>(dst); break;
+	case cft_int16: conv_into<int16_t>(dst); break;
+	case cft_int32: conv_into<int32_t>(dst); break;
 #ifndef BOOST_NO_INT64_T
-	case cft_int64:
-		for (int64_t *p = (int64_t *)&data_, *e = p + num_channels_; p < e;
-			 *p++ = from_string<int64_t>(*s++))
-			;
-		break;
+	case cft_int64: conv_into<int64_t>(dst); break;
 #endif
+	case cft_string: conv_into<std::string>(dst); break;
 	default: throw std::invalid_argument("Unsupported channel format.");
 	}
-	return *this;
 }
 
-sample &sample::retrieve_typed(std::string *d) {
-	switch (format_) {
-	case cft_string:
-		for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; *d++ = *p++)
-			;
-		break;
-	case cft_float32:
-		for (float *p = (float *)&data_, *e = p + num_channels_; p < e; *d++ = to_string(*p++))
-			;
-		break;
-	case cft_double64:
-		for (double *p = (double *)&data_, *e = p + num_channels_; p < e; *d++ = to_string(*p++))
-			;
-		break;
-	case cft_int8:
-		for (int8_t *p = (int8_t *)&data_, *e = p + num_channels_; p < e; *d++ = to_string(*p++))
-			;
-		break;
-	case cft_int16:
-		for (int16_t *p = (int16_t *)&data_, *e = p + num_channels_; p < e; *d++ = to_string(*p++))
-			;
-		break;
-	case cft_int32:
-		for (int32_t *p = (int32_t *)&data_, *e = p + num_channels_; p < e; *d++ = to_string(*p++))
-			;
-		break;
-#ifndef BOOST_NO_INT64_T
-	case cft_int64:
-		for (int64_t *p = (int64_t *)&data_, *e = p + num_channels_; p < e; *d++ = to_string(*p++))
-			;
-		break;
-#endif
-	default: throw std::invalid_argument("Unsupported channel format.");
-	}
-	return *this;
+void lsl::sample::assign_untyped(const void *newdata) {
+	if (format_ != cft_string)
+		memcpy(&data_, newdata, datasize());
+	else
+		throw std::invalid_argument("Cannot assign untyped data to a string-formatted sample.");
+}
+
+void lsl::sample::retrieve_untyped(void *newdata) {
+	if (format_ != cft_string)
+		memcpy(newdata, &data_, datasize());
+	else
+		throw std::invalid_argument("Cannot retrieve untyped data from a string-formatted sample.");
 }
 
 /// Helper function to save raw binary data to a stream buffer.
@@ -157,27 +185,22 @@ void sample::save_streambuf(
 	}
 	// write channel data
 	if (format_ == cft_string) {
-		for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; p++) {
+		for (const auto &str : samplevals<std::string>(*this)) {
 			// write string length as variable-length integer
-			if (p->size() <= 0xFF) {
+			if (str.size() <= 0xFF) {
 				save_value(sb, (uint8_t)sizeof(uint8_t), use_byte_order);
-				save_value(sb, (uint8_t)p->size(), use_byte_order);
+				save_value(sb, static_cast<uint8_t>(str.size()), use_byte_order);
 			} else {
-				if (p->size() <= 0xFFFFFFFF) {
+				if (str.size() <= 0xFFFFFFFF) {
 					save_value(sb, (uint8_t)sizeof(uint32_t), use_byte_order);
-					save_value(sb, (uint32_t)p->size(), use_byte_order);
+					save_value(sb, static_cast<uint32_t>(str.size()), use_byte_order);
 				} else {
-#ifndef BOOST_NO_INT64_T
 					save_value(sb, (uint8_t)sizeof(uint64_t), use_byte_order);
-					save_value(sb, (uint64_t)p->size(), use_byte_order);
-#else
-					save_value(sb, (uint8_t)sizeof(std::size_t), use_byte_order);
-					save_value(sb, (std::size_t)p->size(), use_byte_order);
-#endif
+					save_value(sb, static_cast<std::size_t>(str.size()), use_byte_order);
 				}
 			}
 			// write string contents
-			if (!p->empty()) save_raw(sb, p->data(), p->size());
+			if (!str.empty()) save_raw(sb, str.data(), str.size());
 		}
 	} else {
 		// write numeric data in binary
@@ -185,7 +208,7 @@ void sample::save_streambuf(
 			save_raw(sb, &data_, datasize());
 		} else {
 			memcpy(scratchpad, &data_, datasize());
-			convert_endian(scratchpad);
+			convert_endian(scratchpad, num_channels_, format_sizes[format_]);
 			save_raw(sb, scratchpad, datasize());
 		}
 	}
@@ -203,7 +226,7 @@ void sample::load_streambuf(
 
 	// read channel data
 	if (format_ == cft_string) {
-		for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; p++) {
+		for (auto &str : samplevals<std::string>(*this)) {
 			// read string length as variable-length integer
 			std::size_t len = 0;
 			auto lenbytes = load_value<uint8_t>(sb, use_byte_order);
@@ -221,59 +244,71 @@ void sample::load_streambuf(
 			default: throw std::runtime_error("Stream contents corrupted (invalid varlen int).");
 			}
 			// read string contents
-			p->resize(len);
-			if (len > 0) load_raw(sb, &(*p)[0], len);
+			str.resize(len);
+			if (len > 0) load_raw(sb, &(str[0]), len);
 		}
 	} else {
 		// read numeric channel data
 		load_raw(sb, &data_, datasize());
-		if (use_byte_order != LSL_BYTE_ORDER && format_sizes[format_] > 1) convert_endian(&data_);
+		if (use_byte_order != LSL_BYTE_ORDER && format_sizes[format_] > 1)
+			convert_endian(&data_, num_channels_, format_sizes[format_]);
 		if (suppress_subnormals && format_float[format_]) {
 			if (format_ == cft_float32) {
-				for (uint32_t *p = (uint32_t *)&data_, *e = p + num_channels_; p < e; p++)
-					if (*p && ((*p & UINT32_C(0x7fffffff)) <= UINT32_C(0x007fffff)))
-						*p &= UINT32_C(0x80000000);
+				for (auto &val : samplevals<uint32_t>(*this))
+					if (val && ((val & UINT32_C(0x7fffffff)) <= UINT32_C(0x007fffff)))
+						val &= UINT32_C(0x80000000);
 			} else {
 #ifndef BOOST_NO_INT64_T
-				for (uint64_t *p = (uint64_t *)&data_, *e = p + num_channels_; p < e; p++)
-					if (*p && ((*p & UINT64_C(0x7fffffffffffffff)) <= UINT64_C(0x000fffffffffffff)))
-						*p &= UINT64_C(0x8000000000000000);
+				for (auto &val : samplevals<uint64_t>(*this))
+					if (val &&
+						((val & UINT64_C(0x7fffffffffffffff)) <= UINT64_C(0x000fffffffffffff)))
+						val &= UINT64_C(0x8000000000000000);
 #endif
 			}
 		}
 	}
 }
 
+void lsl::sample::convert_endian(void *data, uint32_t n, uint32_t width) {
+	void *dataptr = reinterpret_cast<void *>(data);
+	switch (width) {
+	case 1: break;
+	case sizeof(int16_t):
+		for (auto &val : dataiter<int16_t>(dataptr, n)) endian_reverse_inplace(val);
+		break;
+	case sizeof(int32_t):
+		for (auto &val : dataiter<int32_t>(dataptr, n)) endian_reverse_inplace(val);
+		break;
+	case sizeof(int64_t):
+		for (auto &val : dataiter<int64_t>(dataptr, n)) endian_reverse_inplace(val);
+		break;
+	default: throw std::runtime_error("Unsupported channel format for endian conversion.");
+	}
+}
+
 template <class Archive> void sample::serialize_channels(Archive &ar, const uint32_t /*unused*/) {
 	switch (format_) {
 	case cft_float32:
-		for (float *p = (float *)&data_, *e = p + num_channels_; p < e; ar & *p++)
-			;
+		for (auto &val : samplevals<float>(*this)) ar &val;
 		break;
 	case cft_double64:
-		for (double *p = (double *)&data_, *e = p + num_channels_; p < e; ar & *p++)
-			;
+		for (auto &val : samplevals<double>(*this)) ar &val;
 		break;
 	case cft_string:
-		for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; ar & *p++)
-			;
+		for (auto &val : samplevals<std::string>(*this)) ar &val;
 		break;
 	case cft_int8:
-		for (int8_t *p = (int8_t *)&data_, *e = p + num_channels_; p < e; ar & *p++)
-			;
+		for (auto &val : samplevals<int8_t>(*this)) ar &val;
 		break;
 	case cft_int16:
-		for (int16_t *p = (int16_t *)&data_, *e = p + num_channels_; p < e; ar & *p++)
-			;
+		for (auto &val : samplevals<int16_t>(*this)) ar &val;
 		break;
 	case cft_int32:
-		for (int32_t *p = (int32_t *)&data_, *e = p + num_channels_; p < e; ar & *p++)
-			;
+		for (auto &val : samplevals<int32_t>(*this)) ar &val;
 		break;
 #ifndef BOOST_NO_INT64_T
 	case cft_int64:
-		for (int64_t *p = (int64_t *)&data_, *e = p + num_channels_; p < e; ar & *p++)
-			;
+		for (auto &val : samplevals<int64_t>(*this)) ar &val;
 		break;
 #endif
 	default: throw std::runtime_error("Unsupported channel format.");
@@ -309,9 +344,9 @@ void sample::load(eos::portable_iarchive &ar, const uint32_t archive_version) {
 template <typename T> void test_pattern(T *data, uint32_t num_channels, int offset) {
 	for (std::size_t k = 0; k < num_channels; k++) {
 		std::size_t val = k + static_cast<std::size_t>(offset);
-		if(std::is_integral<T>::value)
+		if (std::is_integral<T>::value)
 			val %= static_cast<std::size_t>(std::numeric_limits<T>::max());
-		data[k] = ( k % 2 == 0) ? static_cast<T>(val) : -static_cast<T>(val);
+		data[k] = (k % 2 == 0) ? static_cast<T>(val) : -static_cast<T>(val);
 	}
 }
 
@@ -321,29 +356,29 @@ sample &sample::assign_test_pattern(int offset) {
 
 	switch (format_) {
 	case cft_float32:
-		test_pattern(reinterpret_cast<float *>(&data_), num_channels_, offset + 0);
+		test_pattern(samplevals<float>(*this).begin(), num_channels_, offset + 0);
 		break;
 	case cft_double64:
-		test_pattern(reinterpret_cast<double *>(&data_), num_channels_, offset + 16777217);
+		test_pattern(samplevals<double>(*this).begin(), num_channels_, offset + 16777217);
 		break;
 	case cft_string: {
-		std::string *data = (std::string *)&data_;
-		for (int32_t k = 0u; k < (int) num_channels_; k++)
+		std::string *data = samplevals<std::string>(*this).begin();
+		for (int32_t k = 0u; k < (int)num_channels_; k++)
 			data[k] = to_string((k + 10) * (k % 2 == 0 ? 1 : -1));
 		break;
 	}
 	case cft_int32:
-		test_pattern(reinterpret_cast<int32_t *>(&data_), num_channels_, offset + 65537);
+		test_pattern(samplevals<int32_t>(*this).begin(), num_channels_, offset + 65537);
 		break;
 	case cft_int16:
-		test_pattern(reinterpret_cast<int16_t *>(&data_), num_channels_, offset + 257);
+		test_pattern(samplevals<int16_t>(*this).begin(), num_channels_, offset + 257);
 		break;
 	case cft_int8:
-		test_pattern(reinterpret_cast<int8_t *>(&data_), num_channels_, offset + 1);
+		test_pattern(samplevals<int8_t>(*this).begin(), num_channels_, offset + 1);
 		break;
 #ifndef BOOST_NO_INT64_T
 	case cft_int64: {
-		int64_t *data = (int64_t *)&data_;
+		int64_t *data = samplevals<int64_t>(*this).begin();
 		int64_t offset64 = 2147483649ll + offset;
 		for (uint32_t k = 0; k < num_channels_; k++) {
 			data[k] = (k + offset64);
@@ -356,6 +391,13 @@ sample &sample::assign_test_pattern(int offset) {
 	}
 
 	return *this;
+}
+
+lsl::sample::sample(lsl_channel_format_t fmt, uint32_t num_channels, factory *fact)
+	: format_(fmt), num_channels_(num_channels), refcount_(0), next_(nullptr), factory_(fact) {
+	// construct std::strings in the data section via placement new
+	if (format_ == cft_string)
+		for (auto &val : samplevals<std::string>(*this)) new (&val) std::string();
 }
 
 factory::factory(lsl_channel_format_t fmt, uint32_t num_chans, uint32_t num_reserve)
@@ -421,3 +463,19 @@ void factory::reclaim_sample(sample *s) {
 	sample *prev = head_.exchange(s);
 	prev->next_ = s;
 }
+
+// template instantiations
+template void lsl::sample::assign_typed(float const *);
+template void lsl::sample::assign_typed(double const *);
+template void lsl::sample::assign_typed(char const *);
+template void lsl::sample::assign_typed(int16_t const *);
+template void lsl::sample::assign_typed(int32_t const *);
+template void lsl::sample::assign_typed(int64_t const *);
+template void lsl::sample::assign_typed(std::string const *);
+template void lsl::sample::retrieve_typed(float *);
+template void lsl::sample::retrieve_typed(double *);
+template void lsl::sample::retrieve_typed(char *);
+template void lsl::sample::retrieve_typed(int16_t *);
+template void lsl::sample::retrieve_typed(int32_t *);
+template void lsl::sample::retrieve_typed(int64_t *);
+template void lsl::sample::retrieve_typed(std::string *);

--- a/src/sample.h
+++ b/src/sample.h
@@ -4,7 +4,7 @@
 #include "forward.h"
 #include "util/cast.hpp"
 #include <atomic>
-#include <boost/endian/conversion.hpp>
+#include <boost/endian/detail/order.hpp>
 #include <boost/serialization/split_member.hpp>
 #include <iosfwd>
 #include <limits>
@@ -17,17 +17,6 @@ using byteorder = lslboost::endian::order;
 static_assert(byteorder::native == byteorder::little || byteorder::native == byteorder::big, "Unsupported byteorder");
 const int LSL_BYTE_ORDER = (byteorder::native == byteorder::little) ? 1234 : 4321;
 
-// Boost.Endian has no functions to reverse floats, so we pretend they're ints of the same size.
-template <typename T> inline void endian_reverse_inplace(T &t) {
-	lslboost::endian::endian_reverse_inplace(t);
-}
-template <> inline void endian_reverse_inplace(double &t) {
-	endian_reverse_inplace(*((uint64_t *)&t));
-}
-template <> inline void endian_reverse_inplace(float &t) {
-	endian_reverse_inplace(*((uint32_t *)&t));
-}
-
 namespace lsl {
 // assert that the target CPU can represent the double-precision timestamp format required by LSL
 static_assert(sizeof(double) == 8, "Target arch has unexpected double size (!=8)");
@@ -37,8 +26,8 @@ const uint8_t TAG_DEDUCED_TIMESTAMP = 1;
 const uint8_t TAG_TRANSMITTED_TIMESTAMP = 2;
 
 /// channel format properties
-const uint8_t format_sizes[] = {0, sizeof(float), sizeof(double), sizeof(std::string), sizeof(int32_t),
-	sizeof(int16_t), sizeof(int8_t), 8};
+const uint8_t format_sizes[] = {0, sizeof(float), sizeof(double), sizeof(std::string),
+	sizeof(int32_t), sizeof(int16_t), sizeof(int8_t), 8};
 const bool format_ieee754[] = {false, std::numeric_limits<float>::is_iec559,
 	std::numeric_limits<double>::is_iec559, false, false, false, false, false};
 const bool format_subnormal[] = {false,
@@ -70,11 +59,6 @@ public:
 	void reclaim_sample(sample *s);
 
 private:
-	/// ensure that a given value is a multiple of some base, round up if necessary
-	static uint32_t ensure_multiple(uint32_t v, unsigned base) {
-		return (v % base) ? v - (v % base) + base : v;
-	}
-
 	/// Pop a sample from the freelist (multi-producer/single-consumer queue by Dmitry Vjukov)
 	sample *pop_freelist();
 
@@ -122,7 +106,7 @@ private:
 	/// the factory used to reclaim this sample, if any
 	factory *factory_;
 	/// the data payload begins here
-	alignas(8) char data_{0};
+	alignas(8) int32_t data_{0};
 
 public:
 	// === Construction ===
@@ -139,129 +123,23 @@ public:
 
 	std::size_t datasize() const { return format_sizes[format_] * static_cast<std::size_t>(num_channels_); }
 
+	uint32_t num_channels() const { return num_channels_; }
+
 	// === type-safe accessors ===
 
 	/// Assign an array of numeric values (with type conversions).
-	template <class T> sample &assign_typed(const T *s) {
-		if ((sizeof(T) == format_sizes[format_]) &&
-			((std::is_integral<T>::value && format_integral[format_]) ||
-				(std::is_floating_point<T>::value && format_float[format_]))) {
-			memcpy(&data_, s, datasize());
-		} else {
-			switch (format_) {
-			case cft_float32:
-				for (float *p = (float *)&data_, *e = p + num_channels_; p < e; *p++ = (float)*s++)
-					;
-				break;
-			case cft_double64:
-				for (double *p = (double *)&data_, *e = p + num_channels_; p < e;
-					 *p++ = (double)*s++)
-					;
-				break;
-			case cft_int8:
-				for (int8_t *p = (int8_t *)&data_, *e = p + num_channels_; p < e;
-					 *p++ = (int8_t)*s++)
-					;
-				break;
-			case cft_int16:
-				for (int16_t *p = (int16_t *)&data_, *e = p + num_channels_; p < e;
-					 *p++ = (int16_t)*s++)
-					;
-				break;
-			case cft_int32:
-				for (int32_t *p = (int32_t *)&data_, *e = p + num_channels_; p < e;
-					 *p++ = (int32_t)*s++)
-					;
-				break;
-#ifndef BOOST_NO_INT64_T
-			case cft_int64:
-				for (int64_t *p = (int64_t *)&data_, *e = p + num_channels_; p < e;
-					 *p++ = (int64_t)*s++)
-					;
-				break;
-#endif
-			case cft_string:
-				for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e;
-					 *p++ = to_string(*s++))
-					;
-				break;
-			default: throw std::invalid_argument("Unsupported channel format.");
-			}
-		}
-		return *this;
-	}
+	template <class T> void assign_typed(const T *s);
 
 	/// Retrieve an array of numeric values (with type conversions).
-	template <class T> sample &retrieve_typed(T *d) {
-		if ((sizeof(T) == format_sizes[format_]) &&
-			((std::is_integral<T>::value && format_integral[format_]) ||
-				(std::is_floating_point<T>::value && format_float[format_]))) {
-			memcpy(d, &data_, datasize());
-		} else {
-			switch (format_) {
-			case cft_float32:
-				for (float *p = (float *)&data_, *e = p + num_channels_; p < e; *d++ = (T)*p++)
-					;
-				break;
-			case cft_double64:
-				for (double *p = (double *)&data_, *e = p + num_channels_; p < e; *d++ = (T)*p++)
-					;
-				break;
-			case cft_int8:
-				for (int8_t *p = (int8_t *)&data_, *e = p + num_channels_; p < e; *d++ = (T)*p++)
-					;
-				break;
-			case cft_int16:
-				for (int16_t *p = (int16_t *)&data_, *e = p + num_channels_; p < e; *d++ = (T)*p++)
-					;
-				break;
-			case cft_int32:
-				for (int32_t *p = (int32_t *)&data_, *e = p + num_channels_; p < e; *d++ = (T)*p++)
-					;
-				break;
-#ifndef BOOST_NO_INT64_T
-			case cft_int64:
-				for (int64_t *p = (int64_t *)&data_, *e = p + num_channels_; p < e; *d++ = (T)*p++)
-					;
-				break;
-#endif
-			case cft_string:
-				for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e;
-					 *d++ = from_string<T>(*p++))
-					;
-				break;
-			default: throw std::invalid_argument("Unsupported channel format.");
-			}
-		}
-		return *this;
-	}
-
-	/// Assign an array of string values to the sample.
-	sample &assign_typed(const std::string *s);
-
-	/// Retrieve an array of string values from the sample.
-	sample &retrieve_typed(std::string *d);
+	template <class T> void retrieve_typed(T *d);
 
 	// === untyped accessors ===
 
 	/// Assign numeric data to the sample.
-	sample &assign_untyped(const void *newdata) {
-		if (format_ != cft_string)
-			memcpy(&data_, newdata, datasize());
-		else
-			throw std::invalid_argument("Cannot assign untyped data to a string-formatted sample.");
-		return *this;
-	}
+	void assign_untyped(const void *newdata);
 
 	/// Retrieve numeric data from the sample.
-	sample &retrieve_untyped(void *newdata) {
-		if (format_ != cft_string)
-			memcpy(newdata, &data_, datasize());
-		else
-			throw std::invalid_argument(
-				"Cannot retrieve untyped data from a string-formatted sample.");
-		return *this;
-	}
+	void retrieve_untyped(void *newdata);
 
 	// === serialization functions ===
 
@@ -274,35 +152,8 @@ public:
 		std::streambuf &sb, int protocol_version, int use_byte_order, bool suppress_subnormals);
 
 	/// Convert the endianness of channel data in-place.
-	void convert_endian(void *data) const {
-		switch (format_sizes[format_]) {
-		case 1: break;
-		case sizeof(int16_t):
-			for (int16_t *p = (int16_t *)data, *e = p + num_channels_; p < e;
-				 endian_reverse_inplace(*p++))
-				;
-			break;
-		case sizeof(int32_t):
-			for (int32_t *p = (int32_t *)data, *e = p + num_channels_; p < e;
-				 endian_reverse_inplace(*p++))
-				;
-			break;
-#ifndef BOOST_NO_INT64_T
-		case sizeof(int64_t):
-			for (int64_t *p = (int64_t *)data, *e = p + num_channels_; p < e;
-				 endian_reverse_inplace(*p++))
-				;
-			break;
-#else
-		case sizeof(double):
-			for (double *p = (double *)data, *e = p + num_channels_; p < e;
-				 endian_reverse_inplace(*p++))
-				;
-			break;
-#endif
-		default: throw std::runtime_error("Unsupported channel format for endian conversion.");
-		}
-	}
+	static void convert_endian(void *data, uint32_t n, uint32_t width);
+
 	/// Serialize a sample into a portable archive (protocol 1.00).
 	void save(eos::portable_oarchive &ar, const uint32_t archive_version) const;
 
@@ -319,13 +170,7 @@ public:
 
 private:
 	/// Construct a new sample for a given channel format/count combination.
-	sample(lsl_channel_format_t fmt, uint32_t num_channels, factory *fact)
-		: format_(fmt), num_channels_(num_channels), refcount_(0), next_(nullptr), factory_(fact) {
-		if (format_ == cft_string)
-			for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e;
-				 new (p++) std::string())
-				;
-	}
+	sample(lsl_channel_format_t fmt, uint32_t num_channels, factory *fact);
 
 	/// Increment ref count.
 	friend void intrusive_ptr_add_ref(sample *s) {
@@ -339,6 +184,14 @@ private:
 			s->factory_->reclaim_sample(s);
 		}
 	}
+
+	friend void *iterhelper(sample &s) noexcept { return reinterpret_cast<void *>(&s.data_); }
+	friend const void *iterhelper(const sample &s) noexcept {
+		return reinterpret_cast<const void *>(&s.data_);
+	}
+
+	template <typename T, typename U> void conv_from(const U *src);
+	template <typename T, typename U> void conv_into(U *dst);
 };
 
 } // namespace lsl

--- a/testing/test_int_samples.cpp
+++ b/testing/test_int_samples.cpp
@@ -51,3 +51,22 @@ TEST_CASE("consumer_queue_threaded", "[queue][threads]") {
 	CHECK(pulled == size);
 	pusher.join();
 }
+
+TEST_CASE("sample conversion", "[basic]") {
+	lsl::factory fac(lsl_channel_format_t::cft_int64, 2, 1);
+	double values[2] = {1, -1};
+	int64_t buf[2];
+	std::string strbuf[2];
+	for (int i = 0; i < 30; ++i) {
+		auto sample = fac.new_sample(0.0, true);
+		sample->assign_typed(values);
+		sample->retrieve_untyped(buf);
+		sample->retrieve_typed(strbuf);
+		for (int j = 0; j < 1; ++j) {
+			CHECK(values[j] == static_cast<int64_t>(buf[j]));
+			CHECK(strbuf[j] == std::to_string(buf[j]));
+		}
+		values[0] = buf[0] << 1;
+		values[1] = -buf[0];
+	}
+}


### PR DESCRIPTION
A sample has a `char*` array to store the values, but the size and type isn't known at compile time.
The values are iterated over in a cast-happy C++98 for-loop: `for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; ++p)`. Also, sample data can be copied in / out in formats different from the native sample format.

In order to simplify the code, this PR adds a helper class and helper methods, so `for (std::string *p = (std::string *)&data_, *e = p + num_channels_; p < e; ++p) { *p = …; }` becomes `for (auto &val : samplevals<std::string>(*this)) { val = …;}`. It also adds two methods: `conv_from(T* src)` copies the values (converting types if necessary) into the sample data, `conv_into(T* dst)` copies the sample data into `dst` (again, converting the types if necessary). The optimal copying / conversion strategy is found via template overloading.

Even though the implementation is fully in `sample.cpp` instead of `sample.h`, the throughput in a benchmark improved by ~3%.