### PR TITLE
CMake: remove now unneeded bcrypt from link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,7 @@ if(UNIX AND NOT APPLE)
 	endif()
 elseif(WIN32)
 	target_link_libraries(lslobj PRIVATE iphlpapi winmm)
-	target_link_libraries(lslboost PRIVATE bcrypt mswsock ws2_32)
+	target_link_libraries(lslboost PRIVATE mswsock ws2_32)
 	target_compile_definitions(lslobj
 		PRIVATE _CRT_SECURE_NO_WARNINGS
 		PUBLIC LSLNOAUTOLINK # don't use #pragma(lib) in CMake builds


### PR DESCRIPTION
As of 70c001868c6ece914e5ec89d7c8690217bddba05, the Windows builds shouldn't depend on `bcrypt` any more.

As far as I know, @chausner @tobiasherzke are most likely to find a niche compiler on Windows that still needs it. It's not urgent at all, but if you could check it, it'd be great.