### PR TITLE
CMake: add object libraries to the export set for static builds

### DIFF
--- a/.github/workflows/mingw_static.yml
+++ b/.github/workflows/mingw_static.yml
@@ -1,0 +1,55 @@
+name: MinGW Windows static test
+
+on:
+  push:
+    branches: ['*']
+    tags: 
+    paths_ignore: ['docs/**', '.travis.yml']
+  pull_request:
+
+jobs:
+  build:
+    name: MinGW batteries-included
+    runs-on: windows-latest
+    
+    defaults:
+      run:
+        shell: 'msys2 {0}'
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: msys2/setup-msys2@v2
+      with:
+        release: false
+    - name: Configure CMake
+      run: |
+           cmake --version
+           cmake -S . -B build \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX=${PWD}/install \
+                -DLSL_UNITTESTS=ON \
+                -DLSL_BUILD_EXAMPLES=ON \
+                -DLSL_BUILD_STATIC=ON \
+                -Dlslgitrevision=${{ github.sha }} \
+                -Dlslgitbranch=${{ github.ref }} \
+                -DLSL_OPTIMIZATIONS=OFF \
+                -G 'MSYS Makefiles'
+
+    - name: make
+      run: cmake --build build --target install --config Release -j --verbose
+  
+    - name: upload install dir
+      uses: actions/upload-artifact@master
+      with:
+        name: mingw_artifacts
+        path: install
+
+    # run internal tests, ignore test failures on docker (missing IPv6 connectivity)
+    - name: unit tests (internal functions)
+      run: 'install/bin/lsl_test_internal --order rand --wait-for-keypress never --durations yes'
+      timeout-minutes: 5
+    
+    - name: unit tests (exported functions)
+      run: install/bin/lsl_test_exported --wait-for-keypress never --durations yes
+      timeout-minutes: 5
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if(LSL_BUNDLED_PUGIXML)
 	message(STATUS "Using bundled pugixml")
 	target_sources(lslobj PRIVATE thirdparty/pugixml/pugixml.cpp)
 	target_include_directories(lslobj SYSTEM PUBLIC
-		${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/pugixml)
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/pugixml>)
 else()
 	message(STATUS "Using system pugixml")
 	find_package(pugixml REQUIRED)
@@ -178,7 +178,7 @@ target_compile_definitions(lslboost
 		BOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS
 )
 target_include_directories(lslboost SYSTEM PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}/lslboost)
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lslboost>)
 
 # target configuration for the internal lslobj target
 target_link_libraries(lslobj PRIVATE lslboost)
@@ -273,7 +273,12 @@ write_basic_package_version_file(
 	COMPATIBILITY AnyNewerVersion
 )
 
-install(TARGETS lsl
+set(LSLTargets lsl)
+if(LSL_BUILD_STATIC)
+	list(APPEND LSLTargets lslobj lslboost)
+endif()
+
+install(TARGETS ${LSLTargets}
 	EXPORT LSLTargets
 	COMPONENT liblsl
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
For shared builds, the linker combines all object files and CMake discards the private properties of the `lslboost` and `lslobj` targets.
For shared libraries, it just combines the object files and adds references to the interface properties of the two object libraries, so they need to be imported.

Copying the properties manually is messy and error-prone, so this PR adds the two object libraries to the export this. Hopefully fixes #138.