### PR TITLE
Introduce soname to indicate ABI version of shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ project (liblsl
 	HOMEPAGE_URL "https://github.com/sccn/liblsl"
 	)
 
+# API version, to be incremented on backwards-incompatible ABI changes
+set(LSL_ABI_VERSION 2)
+
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 if(NOT MSVC_VERSION VERSION_LESS 1700)
@@ -239,6 +242,7 @@ target_include_directories(lsl INTERFACE
 )
 set_target_properties(lsl PROPERTIES
 	VERSION ${liblsl_VERSION_MAJOR}.${liblsl_VERSION_MINOR}.${liblsl_VERSION_PATCH}
+	SOVERSION ${LSL_ABI_VERSION}
 )
 
 # enable some additional expensive compiler optimizations


### PR DESCRIPTION
Having a "soname" that stays constant allows compiled
executables that link against liblsl to continue to work
whithout recompilation when liblsl is updated as long as
the soname of liblsl stays the same.

Each time the ABI of liblsl changes in future, the setting
LSL_ABI_VERSION in CMakeLists.txt should be incremented by
one to change the soname.  Closes #140.