### PR TITLE
Added socket buffer size options to api_config

### DIFF
--- a/src/api_config.cpp
+++ b/src/api_config.cpp
@@ -207,8 +207,10 @@ void api_config::load_from_file(const std::string &filename) {
 		time_probe_max_rtt_ = pt.get("tuning.TimeProbeMaxRTT", 0.128);
 		outlet_buffer_reserve_ms_ = pt.get("tuning.OutletBufferReserveMs", 5000);
 		outlet_buffer_reserve_samples_ = pt.get("tuning.OutletBufferReserveSamples", 128);
+		socket_send_buffer_size_ = pt.get("tuning.SendSocketBufferSize", 0);
 		inlet_buffer_reserve_ms_ = pt.get("tuning.InletBufferReserveMs", 5000);
 		inlet_buffer_reserve_samples_ = pt.get("tuning.InletBufferReserveSamples", 128);
+		socket_receive_buffer_size_ = pt.get("tuning.ReceiveSocketBufferSize", 0);
 		smoothing_halftime_ = pt.get("tuning.SmoothingHalftime", 90.0F);
 		force_default_timestamps_ = pt.get("tuning.ForceDefaultTimestamps", false);
 

--- a/src/api_config.h
+++ b/src/api_config.h
@@ -174,10 +174,14 @@ public:
 	int outlet_buffer_reserve_ms() const { return outlet_buffer_reserve_ms_; }
 	/// Default pre-allocated buffer size for the outlet, in samples (irregular streams).
 	int outlet_buffer_reserve_samples() const { return outlet_buffer_reserve_samples_; }
+	/// Default socket send buffer size, in bytes.
+	int socket_send_buffer_size() const { return socket_send_buffer_size_; }
 	/// Default pre-allocated buffer size for the inlet, in ms (regular streams).
 	int inlet_buffer_reserve_ms() const { return inlet_buffer_reserve_ms_; }
 	/// Default pre-allocated buffer size for the inlet, in samples (irregular streams).
 	int inlet_buffer_reserve_samples() const { return inlet_buffer_reserve_samples_; }
+	/// Default socket receive buffer size, in bytes.
+	int socket_receive_buffer_size() const { return socket_receive_buffer_size_; }
 	/// Default halftime of the time-stamp smoothing window (if enabled), in seconds.
 	float smoothing_halftime() const { return smoothing_halftime_; }
 	/// Override timestamps with lsl clock if True
@@ -235,8 +239,10 @@ private:
 	double time_probe_max_rtt_;
 	int outlet_buffer_reserve_ms_;
 	int outlet_buffer_reserve_samples_;
+	int socket_send_buffer_size_;
 	int inlet_buffer_reserve_ms_;
 	int inlet_buffer_reserve_samples_;
+	int socket_receive_buffer_size_;
 	float smoothing_halftime_;
 	bool force_default_timestamps_;
 };

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -267,6 +267,10 @@ client_session::~client_session() {
 void client_session::begin_processing() {
 	try {
 		sock_->set_option(asio::ip::tcp::no_delay(true));
+		if (api_config::get_instance()->socket_send_buffer_size() > 0)
+			sock_->set_option(asio::socket_base::send_buffer_size(api_config::get_instance()->socket_send_buffer_size()));
+		if (api_config::get_instance()->socket_receive_buffer_size() > 0)
+			sock_->set_option(asio::socket_base::receive_buffer_size (api_config::get_instance()->socket_receive_buffer_size()));
 		// register this socket as "in-flight" with the server (so that any subsequent ops on it can
 		// be aborted if necessary)
 		serv_->register_inflight_socket(sock_);


### PR DESCRIPTION
This allows setting the TCP socket buffer sizes via lsl_api.cfg

I think the default socket buffer size is different on every platform so instead of assuming a default I just set the default to `0` then only update the socket with the API value if it's larger than 0.