### PR TITLE
Two minor stream resolution improvements

### DIFF
--- a/include/lsl_cpp.h
+++ b/include/lsl_cpp.h
@@ -1668,7 +1668,7 @@ public:
 	std::vector<stream_info> results() {
 		lsl_streaminfo buffer[1024];
 		return std::vector<stream_info>(
-			buffer, buffer + lsl_resolver_results(obj.get(), buffer, sizeof(buffer)));
+			buffer, buffer + check_error(lsl_resolver_results(obj.get(), buffer, sizeof(buffer))));
 	}
 
 	/// Move constructor for stream_inlet

--- a/src/resolve_attempt_udp.cpp
+++ b/src/resolve_attempt_udp.cpp
@@ -135,6 +135,10 @@ void resolve_attempt_udp::handle_receive_outcome(err_t err, std::size_t len) {
 							stored_info.v6address(remote_endpoint_.address().to_string());
 					}
 				}
+				// prepone the next cancellation check, i.e. when all needed streams are found,
+				// cancel immediately rather than when a wave timer is due half a second later
+				if (resolver_.check_cancellation_criteria())
+					resolver_.cancel_ongoing_resolve();
 			}
 		} catch (std::exception &e) {
 			LOG_F(WARNING, "resolve_attempt_udp: hiccup while processing the received data: %s",

--- a/src/resolve_attempt_udp.cpp
+++ b/src/resolve_attempt_udp.cpp
@@ -12,11 +12,11 @@
 using namespace lsl;
 
 resolve_attempt_udp::resolve_attempt_udp(asio::io_context &io, const udp &protocol,
-	const std::vector<udp::endpoint> &targets, const std::string &query, result_container &results,
-	std::mutex &results_mut, double cancel_after, cancellable_registry *registry)
-	: io_(io), results_(results), results_mut_(results_mut), cancel_after_(cancel_after),
-	  cancelled_(false), targets_(targets), query_(query), unicast_socket_(io),
-	  broadcast_socket_(io), multicast_socket_(io), recv_socket_(io), cancel_timer_(io) {
+	const std::vector<udp::endpoint> &targets, const std::string &query, resolver_impl &resolver,
+	double cancel_after)
+	: io_(io), resolver_(resolver), cancel_after_(cancel_after), cancelled_(false),
+	  targets_(targets), query_(query), unicast_socket_(io), broadcast_socket_(io),
+	  multicast_socket_(io), recv_socket_(io), cancel_timer_(io) {
 	// open the sockets that we might need
 	recv_socket_.open(protocol);
 	try {
@@ -56,7 +56,7 @@ resolve_attempt_udp::resolve_attempt_udp(asio::io_context &io, const udp &protoc
 		query_msg_.c_str());
 
 	// register ourselves as a candidate for cancellation
-	if (registry) register_at(registry);
+	register_at(&resolver);
 }
 
 resolve_attempt_udp::~resolve_attempt_udp() {
@@ -115,20 +115,24 @@ void resolve_attempt_udp::handle_receive_outcome(err_t err, std::size_t len) {
 				std::string uid = info.uid();
 				{
 					// update the results
-					std::lock_guard<std::mutex> lock(results_mut_);
-					if (results_.find(uid) == results_.end())
-						results_[uid] = std::make_pair(info, lsl_clock()); // insert new result
+					std::lock_guard<std::mutex> lock(resolver_.results_mut_);
+					auto it = resolver_.results_.find(uid);
+					if (it == resolver_.results_.end())
+						// insert new result, store iterator in it
+						it = resolver_.results_.emplace(uid, std::make_pair(info, lsl_clock()))
+								 .first;
 					else
-						results_[uid].second = lsl_clock(); // update only the receive time
+						it->second.second = lsl_clock(); // update only the receive time
+					auto &stored_info = it->second.first;
 					// ... also update the address associated with the result (but don't
 					// override the address of an earlier record for this stream since this
 					// would be the faster route)
 					if (remote_endpoint_.address().is_v4()) {
-						if (results_[uid].first.v4address().empty())
-							results_[uid].first.v4address(remote_endpoint_.address().to_string());
+						if (stored_info.v4address().empty())
+							stored_info.v4address(remote_endpoint_.address().to_string());
 					} else {
-						if (results_[uid].first.v6address().empty())
-							results_[uid].first.v6address(remote_endpoint_.address().to_string());
+						if (stored_info.v6address().empty())
+							stored_info.v6address(remote_endpoint_.address().to_string());
 					}
 				}
 			}

--- a/src/resolve_attempt_udp.h
+++ b/src/resolve_attempt_udp.h
@@ -53,8 +53,7 @@ public:
 	 */
 	resolve_attempt_udp(asio::io_context &io, const udp &protocol,
 		const std::vector<udp::endpoint> &targets, const std::string &query,
-		result_container &results, std::mutex &results_mut, double cancel_after = 5.0,
-		cancellable_registry *registry = nullptr);
+		resolver_impl &resolver, double cancel_after = 5.0);
 
 	/// Destructor
 	~resolve_attempt_udp();
@@ -90,10 +89,8 @@ private:
 	// data shared with the resolver_impl
 	/// reference to the IO service that executes our actions
 	asio::io_context &io_;
-	/// shared result container
-	result_container &results_;
-	/// shared mutex that protects the results
-	std::mutex &results_mut_;
+	/// the resolver associated with this attempt
+	resolver_impl &resolver_;
 
 	// constant over the lifetime of this attempt
 	/// the timeout for giving up

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -206,8 +206,8 @@ void resolver_impl::udp_multicast_burst() {
 	int failures = 0;
 	for (auto protocol: udp_protocols_) {
 		try {
-			std::make_shared<resolve_attempt_udp>(*io_, protocol, mcast_endpoints_, query_,
-				results_, results_mut_, cfg_->multicast_max_rtt(), this)
+			std::make_shared<resolve_attempt_udp>(
+				*io_, protocol, mcast_endpoints_, query_, *this, cfg_->multicast_max_rtt())
 				->begin();
 		} catch (std::exception &e) {
 			if (++failures == udp_protocols_.size())
@@ -226,8 +226,8 @@ void resolver_impl::udp_unicast_burst(err_t err) {
 	// start one per IP stack under consideration
 	for (auto protocol: udp_protocols_) {
 		try {
-			std::make_shared<resolve_attempt_udp>(*io_, protocol, ucast_endpoints_, query_,
-				results_, results_mut_, cfg_->unicast_max_rtt(), this)
+			std::make_shared<resolve_attempt_udp>(
+				*io_, protocol, ucast_endpoints_, query_, *this, cfg_->unicast_max_rtt())
 				->begin();
 		} catch (std::exception &e) {
 			if (++failures == udp_protocols_.size())

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -203,7 +203,7 @@ void resolver_impl::next_resolve_wave() {
 
 void resolver_impl::udp_multicast_burst() {
 	// start one per IP stack under consideration
-	int failures = 0;
+	unsigned int failures = 0;
 	for (auto protocol: udp_protocols_) {
 		try {
 			std::make_shared<resolve_attempt_udp>(
@@ -222,7 +222,7 @@ void resolver_impl::udp_multicast_burst() {
 void resolver_impl::udp_unicast_burst(err_t err) {
 	if (err == asio::error::operation_aborted) return;
 
-	int failures = 0;
+	unsigned int failures = 0;
 	// start one per IP stack under consideration
 	for (auto protocol: udp_protocols_) {
 		try {

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -49,11 +49,9 @@ resolver_impl::resolver_impl()
 	// generate the list of protocols to use
 	if (cfg_->allow_ipv6()) {
 		udp_protocols_.push_back(udp::v6());
-		tcp_protocols_.push_back(tcp::v6());
 	}
 	if (cfg_->allow_ipv4()) {
 		udp_protocols_.push_back(udp::v4());
-		tcp_protocols_.push_back(tcp::v4());
 	}
 }
 

--- a/src/resolver_impl.h
+++ b/src/resolver_impl.h
@@ -124,6 +124,10 @@ public:
 	 */
 	void cancel();
 
+	enum class resolver_status {
+		empty, started_oneshot, running_continuous
+	};
+
 private:
 	/// This function starts a new wave of resolves.
 	void next_resolve_wave();
@@ -157,6 +161,7 @@ private:
 	std::atomic<bool> expired_;
 
 	// reinitialized for each query
+	resolver_status status{resolver_status::empty};
 	/// our current query string
 	std::string query_;
 	/// the minimum number of results that we want

--- a/src/resolver_impl.h
+++ b/src/resolver_impl.h
@@ -129,6 +129,8 @@ public:
 	};
 
 private:
+	friend class resolve_attempt_udp;
+
 	/// This function starts a new wave of resolves.
 	void next_resolve_wave();
 

--- a/src/resolver_impl.h
+++ b/src/resolver_impl.h
@@ -140,6 +140,9 @@ private:
 	/// Start a new resolver attempt on the known peers.
 	void udp_unicast_burst(err_t err);
 
+	/// Check if cancellation criteria (minimum number of results, timeout) are met
+	bool check_cancellation_criteria();
+
 	/// Cancel the currently ongoing resolve, if any.
 	void cancel_ongoing_resolve();
 

--- a/src/resolver_impl.h
+++ b/src/resolver_impl.h
@@ -149,8 +149,6 @@ private:
 	const api_config *cfg_;
 	/// UDP protocols under consideration
 	std::vector<udp> udp_protocols_;
-	/// TCP protocols under consideration
-	std::vector<tcp> tcp_protocols_;
 	/// the list of multicast endpoints under consideration
 	std::vector<udp::endpoint> mcast_endpoints_;
 	/// the list of per-host UDP endpoints under consideration


### PR DESCRIPTION
This PR includes two improvements to the resolver.

8eec428 raises exceptions for some documented invalid operations:

``` cpp
lsl::resolver_impl resolver;
resolver.results(); // throws, no resolve started so far
resolver.resolve_continuous(…); // ok
resolver.resolve_oneshot(); // throws, continuous resolution in progress
resolver.resolve_continuous(…); // throws, continuous resolution in progress
```

b7af329 speeds up stream resolution by up to `multicast_min_rtt`. By default, `resolver_impl::resolve_oneshot()` sends query packets, waits for results and checks if enough streams have been found whenever a new round of query packets is sent (once ever `multicast_min_rtt` seconds, 0.5 by default. b7af329 checks the completion criteria every time a new stream has been found so stream resolution can finish much sooner. This makes it possible to raise the `multicast_min_rtt` (as it doesn't influence the initial stream resolution time) and speeds up stream recovery (which relies on `resolve_oneshot()`).