### PR TITLE
Optimize endianness operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ add_library(lslobj OBJECT
 	src/udp_server.h
 	src/util/cast.hpp
 	src/util/cast.cpp
+	src/util/endian.cpp
+	src/util/endian.hpp
 	src/util/inireader.hpp
 	src/util/inireader.cpp
 	src/util/strfuns.hpp

--- a/src/sample.h
+++ b/src/sample.h
@@ -3,19 +3,15 @@
 #include "common.h"
 #include "forward.h"
 #include "util/cast.hpp"
+#include "util/endian.hpp"
 #include <atomic>
 #include <cstdint>
-#include <boost/endian/detail/order.hpp>
 #include <iosfwd>
 #include <limits>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
 
-// Determine target byte order / endianness
-using byteorder = lslboost::endian::order;
-static_assert(byteorder::native == byteorder::little || byteorder::native == byteorder::big, "Unsupported byteorder");
-const int LSL_BYTE_ORDER = (byteorder::native == byteorder::little) ? 1234 : 4321;
 
 namespace lsl {
 // assert that the target CPU can represent the double-precision timestamp format required by LSL
@@ -144,12 +140,12 @@ public:
 	// === serialization functions ===
 
 	/// Serialize a sample to a stream buffer (protocol 1.10).
-	void save_streambuf(std::streambuf &sb, int protocol_version, int use_byte_order,
+	void save_streambuf(std::streambuf &sb, int protocol_version, bool reverse_byte_order,
 		void *scratchpad = nullptr) const;
 
 	/// Deserialize a sample from a stream buffer (protocol 1.10).
-	void load_streambuf(
-		std::streambuf &sb, int protocol_version, int use_byte_order, bool suppress_subnormals);
+	void load_streambuf(std::streambuf &sb, int protocol_version, bool reverse_byte_order,
+		bool suppress_subnormals);
 
 	/// Convert the endianness of channel data in-place.
 	static void convert_endian(void *data, uint32_t n, uint32_t width);

--- a/src/socket_utils.cpp
+++ b/src/socket_utils.cpp
@@ -1,17 +1,6 @@
 #include "socket_utils.h"
 #include "api_config.h"
 #include "common.h"
-#include <boost/endian/conversion.hpp>
-
-double lsl::measure_endian_performance() {
-	const double measure_duration = 0.01;
-	const double t_end = lsl_clock() + measure_duration;
-	uint64_t data = 0x01020304;
-	double k;
-	for (k = 0; ((int)k & 0xFF) != 0 || lsl_clock() < t_end; k++)
-		lslboost::endian::endian_reverse_inplace(data);
-	return k;
-}
 
 template <typename Socket, typename Protocol>
 uint16_t bind_port_in_range_(Socket &sock, Protocol protocol) {

--- a/src/socket_utils.h
+++ b/src/socket_utils.h
@@ -15,9 +15,6 @@ uint16_t bind_port_in_range(asio::ip::udp::socket &sock, asio::ip::udp protocol)
 /// Bind and listen to an acceptor on a free port in the configured port range or throw an error.
 uint16_t bind_and_listen_to_port_in_range(
 	asio::ip::tcp::acceptor &acc, asio::ip::tcp protocol, int backlog);
-
-/// Measure the endian conversion performance of this machine.
-double measure_endian_performance();
 } // namespace lsl
 
 #endif

--- a/src/util/endian.cpp
+++ b/src/util/endian.cpp
@@ -1,0 +1,12 @@
+#include "endian.hpp"
+#include "../common.h"
+
+double lsl::measure_endian_performance() {
+	const double measure_duration = 0.01;
+	const double t_end = lsl_clock() + measure_duration;
+	uint64_t data = 0x01020304;
+	double k;
+	for (k = 0; ((int)k & 0xFF) != 0 || lsl_clock() < t_end; k++)
+		lslboost::endian::endian_reverse_inplace(data);
+	return k;
+}

--- a/src/util/endian.hpp
+++ b/src/util/endian.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <boost/endian/conversion.hpp>
+
+namespace lsl {
+
+using lslboost::endian::endian_reverse_inplace;
+using byteorder = lslboost::endian::order;
+
+enum Endianness {
+	LSL_PORTABLE_ENDIAN = 0,
+	LSL_LITTLE_ENDIAN_BUT_BIG_FLOAT = 1,
+	LSL_BIG_ENDIAN_BUT_LITTLE_FLOAT = 2,
+	LSL_LITTLE_ENDIAN = 1234,
+	LSL_BIG_ENDIAN = 4321,
+	LSL_PDP11 = 2134 // deprecated, not used nowadays
+};
+
+/// the host native byte order
+const Endianness LSL_BYTE_ORDER =
+	(byteorder::native == byteorder::little) ? LSL_LITTLE_ENDIAN : LSL_BIG_ENDIAN;
+
+inline bool can_convert_endian(Endianness requested, int value_size) {
+	if(value_size == 1) return true;
+	if (requested != LSL_LITTLE_ENDIAN && requested != LSL_BIG_ENDIAN)
+		return false;
+	if (LSL_BYTE_ORDER != LSL_LITTLE_ENDIAN && LSL_BYTE_ORDER != LSL_BIG_ENDIAN)
+		return false;
+	return true;
+}
+inline bool can_convert_endian(int requested, int value_size) {
+	return can_convert_endian(static_cast<Endianness>(requested), value_size);
+}
+
+/// Measure the endian conversion performance of this machine.
+double measure_endian_performance();
+
+// Determine target byte order / endianness
+using byteorder = lslboost::endian::order;
+static_assert(byteorder::native == byteorder::little || byteorder::native == byteorder::big,
+	"Unsupported byteorder");
+
+
+} // namespace lsl

--- a/testing/ext/DataType.cpp
+++ b/testing/ext/DataType.cpp
@@ -37,7 +37,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEST_CASE("data datatransfer", "[datatransfer][multi][string]") {
-	const std::size_t numChannels = 2;
+	const std::size_t numChannels = 3;
 
 	Streampair sp(create_streampair(lsl::stream_info(
 		"cf_string", "DataType", numChannels, lsl::IRREGULAR_RATE, lsl::cf_string, "streamid")));
@@ -45,6 +45,7 @@ TEST_CASE("data datatransfer", "[datatransfer][multi][string]") {
 	std::vector<std::string> sent_data, received_data(numChannels);
 	const char nullstr[] = "\0Test\0string\0with\0nulls";
 	sent_data.emplace_back(nullstr, sizeof(nullstr));
+	sent_data.emplace_back(200, 'x');
 	sent_data.emplace_back(1 << 20, 'x');
 
 	sp.out_.push_sample(sent_data);


### PR DESCRIPTION
This PR contains four improvements to endianness operations:

- Move endianness detection / helpers to utils/endian.hpp
  Endianness checks / conversions are gathered in one place
- Only store if endianness should be swapped, not the desired endianness. As Boost.Endian only supports swapping between little and big endian, this makes the code a bit easier to read and reason about.
- Pre-compute endian conversion performance once
  The endian conversion performance is measured only first time it is requested, speeding up the connection handshake by 10ms.
- Optimize single-byte writes/reads
  Reading / writing single bytes uses `streambuf::sbumpc()` and `streambuf::sgetc()` instead of reading/writing buffers of length one. It also makes the code a bit shorter by omitting the `reverse_byte_order` parameter.