### PR TITLE
Fix accidental protocol downgrade

### DIFF
--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -427,7 +427,9 @@ void client_session::handle_read_feedparams(
 				api_config::get_instance()->use_protocol_version(), client_protocol_version);
 			// downgrade to 1.00 (portable binary format) if an unsupported binary conversion is
 			// involved
-			if (serv_->info_->channel_bytes() != client_value_size) data_protocol_version_ = 100;
+			if (serv_->info_->channel_format() != cft_string &&
+				serv_->info_->channel_bytes() != client_value_size)
+				data_protocol_version_ = 100;
 			if (!format_ieee754[cft_double64] ||
 				(format == cft_float32 && !format_ieee754[cft_float32]) ||
 				!client_has_ieee754_floats)


### PR DESCRIPTION
The size of `std::string` is implementation-defined but not relevant for protocol version 110. A size mismatch is therefore not a reason to downgrade the data protocol to 100.