### PR TITLE
Fix two MSVC warnings

### DIFF
--- a/src/stream_info_impl.cpp
+++ b/src/stream_info_impl.cpp
@@ -256,7 +256,7 @@ uint32_t lsl::stream_info_impl::calc_transport_buf_samples(
 	else if (nominal_srate() == LSL_IRREGULAR_RATE)
 		buf_samples = requested_len * 100;
 	else
-		buf_samples = (int32_t)(nominal_srate() * requested_len);
+		buf_samples = static_cast<int32_t>(nominal_srate() * requested_len);
 	if (flags & transp_bufsize_thousandths) buf_samples /= 1000;
 	buf_samples = (buf_samples > 0) ? buf_samples : 1;
 	return buf_samples;

--- a/src/stream_info_impl.cpp
+++ b/src/stream_info_impl.cpp
@@ -256,7 +256,7 @@ uint32_t lsl::stream_info_impl::calc_transport_buf_samples(
 	else if (nominal_srate() == LSL_IRREGULAR_RATE)
 		buf_samples = requested_len * 100;
 	else
-		buf_samples = nominal_srate() * requested_len;
+		buf_samples = (int32_t)(nominal_srate() * requested_len);
 	if (flags & transp_bufsize_thousandths) buf_samples /= 1000;
 	buf_samples = (buf_samples > 0) ? buf_samples : 1;
 	return buf_samples;

--- a/src/time_postprocessor.cpp
+++ b/src/time_postprocessor.cpp
@@ -4,8 +4,9 @@
 #include <limits>
 #include <utility>
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
-#ifdef __clang__
+#elif defined(__clang__)
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
 #endif
 


### PR DESCRIPTION
This fixes the following warning with MSVC:
> ...\src\time_postprocessor.cpp(7,9): warning C4068: Unknown pragma "GCC".

Before this change, this pragma was active when compiling with clang. I am not sure if this was on purpose and whether it has any effect on clang. If yes, I can change the condition to:
```c++
if defined(__GNUC__) || defined(__clang__)
```

It also fixes another minor implicit conversion warning.