### PR TITLE
Build MinGW on Windows server 2019

### DIFF
--- a/.github/workflows/mingw_static.yml
+++ b/.github/workflows/mingw_static.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: MinGW batteries-included
-    runs-on: windows-latest
+    runs-on: windows-2019
     
     defaults:
       run:


### PR DESCRIPTION
MinGW build on Github Actions Windows Server 2022 runner failed because CMake was not found in PATH from MSYS2 shell.
CMake is found in Github Actions Windows Server 2019 runner.

For MinGW compilation, exact OS version of the build host is irrelevant.