### PR TITLE
Add concurrency cancellation to GHA workflows.

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -19,10 +19,13 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
-
 
 jobs:
   build:

--- a/.github/workflows/mingw_static.yml
+++ b/.github/workflows/mingw_static.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/mingw_static.yml'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: MinGW batteries-included


### PR DESCRIPTION
Hopefully this stops a single push to a pull request from double-running workflows.

In my other branch, it didn't seem to help. Maybe it only works if it's already on master? (there are some weird GHA things like that)