### PR TITLE
:bug: implicit type conversion prevented importing the native library

### DIFF
--- a/include/lsl_cpp.h
+++ b/include/lsl_cpp.h
@@ -324,7 +324,8 @@ public:
 
 	/// lsl_stream_info_matches_query
 	bool matches_query(const char *query) const {
-		return lsl_stream_info_matches_query(obj.get(), query);
+		int result = lsl_stream_info_matches_query(obj.get(), query);
+		return result != 0; 
 	}
 
 


### PR DESCRIPTION
When importing the native library into Unreal Engine (not the plugin) the implicit conversion from int to bool would crash the build. 
With explicit conversion the build succeeds and the functionality is preserved.