### PR TITLE
Add LSL_NO_PACKAGING variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,12 @@ if(LSL_BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
 
+option(
+	LSL_NO_PACKAGING
+	"Disable LSLGenerateCPackConfig and skip creating a package for liblsl"
+	OFF
+)
+
 if(NOT LSL_NO_PACKAGING)
 	LSLGenerateCPackConfig()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ option(LSL_UNITTESTS "Build LSL library unit tests" OFF)
 option(LSL_BUNDLED_BOOST "Use the bundled Boost by default" ON)
 option(LSL_BUNDLED_PUGIXML "Use the bundled pugixml by default" ON)
 option(LSL_TOOLS "Build some experimental tools for in-depth tests" OFF)
+option(
+	LSL_NO_PACKAGING
+	"Disable LSLGenerateCPackConfig and skip creating a package for liblsl"
+	OFF
+)
 
 mark_as_advanced(LSL_FORCE_FANCY_LIBNAME)
 
@@ -348,12 +353,6 @@ endif()
 if(LSL_BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
-
-option(
-	LSL_NO_PACKAGING
-	"Disable LSLGenerateCPackConfig and skip creating a package for liblsl"
-	OFF
-)
 
 if(NOT LSL_NO_PACKAGING)
 	LSLGenerateCPackConfig()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,4 +349,6 @@ if(LSL_BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
 
-LSLGenerateCPackConfig()
+if(NOT LSL_NO_PACKAGING)
+	LSLGenerateCPackConfig()
+endif()


### PR DESCRIPTION
Hello, I'm not sure if this is the cleaner way; but I'd like to statically link `liblsl` in a LabRecorder `.deb` package. My binary correctly includes it, and `ldd` shows the dependency on `liblsl` gone with a working LabRecorder. Yet, if I try to install the `.deb`, I get `Depends: liblsl (= 1.16.5-noble) but it is not installable` because `liblsl` still produces a `.deb` file along mine. 

I'd like to add this argument to be able to set `-DLSL_NO_PACKAGING=ON` in the `cmake` configuration.