### PR TITLE
Allow liblsl compilation with c++14.

### DIFF
--- a/src/portable_archive/portable_iarchive.hpp
+++ b/src/portable_archive/portable_iarchive.hpp
@@ -194,8 +194,9 @@ public:
 		// after reading the note above you still might decide to
 		// deactivate this static assert and try if it works out.
 		typename traits::bits bits;
-		static_assert(sizeof(bits) == sizeof(T));
-		static_assert(std::numeric_limits<T>::is_iec559);
+		static_assert(sizeof(bits) == sizeof(T), "mismatching type sizes");
+		static_assert(std::numeric_limits<T>::is_iec559,
+			"floating point type does not conform to IEC 559 (IEEE 754)");
 
 		load(bits);
 		traits::set_bits(t, bits);

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -356,7 +356,7 @@ void lsl::sample::serialize(eos::portable_iarchive &ar, const uint32_t archive_v
 template <typename T> void test_pattern(T *data, uint32_t num_channels, int offset) {
 	for (std::size_t k = 0; k < num_channels; k++) {
 		std::size_t val = k + static_cast<std::size_t>(offset);
-		if (std::is_integral_v<T>) val %= static_cast<std::size_t>(std::numeric_limits<T>::max());
+		if (std::is_integral<T>::value) val %= static_cast<std::size_t>(std::numeric_limits<T>::max());
 		data[k] = (k % 2 == 0) ? static_cast<T>(val) : -static_cast<T>(val);
 	}
 }


### PR DESCRIPTION
This PR makes two minor changes:

- Add a error message to `static_assert` calls
- replace the singular instance of `std::is_integral_v<T>` with `std::is_integral<T>::value`

These changes do not impact anything else, but make it compatible with C++14 standard.

**Why?**

With this change, I have successfully compiled and tested my Dart api wrapper on `ARMv7` (BELA / BeagleBone black).

SBC/Embedded devices are often running older / restricted hardware, and the BELA runs a variant of Debian 9 (Stretch). This means the compilers are outdated, and the latest available Clang / LLVM is version 7, and the highest C/CPP version available is 14.
