### PR TITLE
Possibly fix #218 - next->_next might be unavailble.

### DIFF
--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -466,11 +466,13 @@ sample *factory::pop_freelist() {
 }
 
 factory::~factory() {
-	for (sample *cur = tail_, *next = cur->next_;; cur = next, next = next->next_) {
-		if (cur != sentinel()) delete cur;
-		if (!next) break;
-	}
-	delete[] storage_;
+	sample *cur = tail_;
+    while (cur) {
+        sample *next = cur->next_;  // Save next pointer before potentially deleting cur
+        if (cur != sentinel()) delete cur;
+        cur = next;
+    }
+    delete[] storage_;
 }
 
 void factory::reclaim_sample(sample *s) {


### PR DESCRIPTION
When cur is deleted, next might become invalid. I've run this test locally and it passes, but I also couldn't get it to fail with the previous implementation, but I see it failing in the test outputs.

If this invokes the test runner we can see if the issue persisits.