### PR TITLE
For the case of the 1 second sleep, the test will fail before the sleep.

### DIFF
--- a/testing/ext/discovery.cpp
+++ b/testing/ext/discovery.cpp
@@ -7,15 +7,20 @@
 namespace {
 
 TEST_CASE("resolve multiple streams", "[resolver][basic]") {
-	lsl::continuous_resolver resolver("type", "Resolve", 50.);
+	// First create the outlets (to avoid extra waiting for
+	// multiple resolves)
 	std::vector<lsl::stream_outlet> outlets;
 	const int n = 3;
 	for (int i = 0; i < n; i++)
 		outlets.emplace_back(lsl::stream_info("resolvetest_" + std::to_string(i), "Resolve"));
-	auto found_stream_info = lsl::resolve_stream("type", "Resolve", n, 2.0);
+	lsl::continuous_resolver resolver("type", "Resolve", 50.);
 
-	// Allow the resolver a bit more time in case the first resolve wave was too fast
-	std::this_thread::sleep_for(std::chrono::seconds(1));
+	// Verify with one-time resolve
+	auto found_stream_info = lsl::resolve_stream("type", "Resolve", n, 2.0);
+	REQUIRE(found_stream_info.size() == n);
+
+	// Allow for enough time (interval, min_rtt)
+	std::this_thread::sleep_for(std::chrono::milliseconds(1600));
 	REQUIRE(resolver.results().size() == n);
 }
 


### PR DESCRIPTION
I noticed my MacOS test runner failed because the number of resolved streams were less than expected (2 instead of 3) see action output: https://github.com/NexusDynamic/liblsl/actions/runs/19069877370/job/54469644449#step:11:605

```text
-------------------------------------------------------------------------------
resolve multiple streams
-------------------------------------------------------------------------------
/Users/runner/work/liblsl/liblsl/testing/ext/discovery.cpp:9
...............................................................................

/Users/runner/work/liblsl/liblsl/testing/ext/discovery.cpp:20: FAILED:
  REQUIRE( resolver.results().size() == n )
with expansion:
  2 == 3

0.000 s: resolve multiple streams
0.000 s: multithreaded lsl_last_error
```

I checked the test to see why it was failing, and I saw that it checks the result, then sleeps to allow time for stream discovery then checks again, but if it fails the first check then the test will fail.

This fix just removes the first check and always waits.



