### PR TITLE
Avoid double free by returning if consumer is not in send buffer.

### DIFF
--- a/src/send_buffer.cpp
+++ b/src/send_buffer.cpp
@@ -39,7 +39,11 @@ void send_buffer::register_consumer(consumer_queue *q) {
 void send_buffer::unregister_consumer(consumer_queue *q) {
 	std::lock_guard<std::mutex> lock(consumers_mut_);
 	auto pos = std::find(consumers_.begin(), consumers_.end(), q);
-	if (pos == consumers_.end()) LOG_F(ERROR, "Trying to remove consumer queue not in send buffer");
+	// If not found, log an error and return
+	if (pos == consumers_.end()) {
+		LOG_F(ERROR, "Trying to remove consumer queue not in send buffer");
+		return;
+	}
 
 	// Put the element to be removed at the end (if it isn't there already) and
 	// remove the last element


### PR DESCRIPTION
Trying my hand at fixing that frustrating segmentation fault bug on CI (I cannot repro locally)...I came across a double free exception I hadn't seen before in the runner.

```text
stringconversion - int64_t

/home/runner/work/liblsl/liblsl/testing/ext/bench_pushpull.cpp:56 ............................................................................... double free or corruption (out)
```

This PR just returns if the consumer isn't in the queue instead of calling swap. If `consumers_.empty()` then the [return value of `consumers_.back()` is undefined](https://en.cppreference.com/w/cpp/container/vector/back), potentially resulting in a corruption during swap.