### PR TITLE
Leverage std::string overloads in pugixml 1.15

### DIFF
--- a/src/stream_info_impl.cpp
+++ b/src/stream_info_impl.cpp
@@ -47,7 +47,11 @@ template <typename T> void append_text_node(xml_node &node, const char *name, co
 }
 
 template <> void append_text_node(xml_node &node, const char *name, const std::string &value) {
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	node.append_child(name).append_child(node_pcdata).set_value(value);
+#else
 	node.append_child(name).append_child(node_pcdata).set_value(value.c_str());
+#endif
 }
 
 void stream_info_impl::write_xml(xml_document &doc) {
@@ -264,17 +268,29 @@ uint32_t lsl::stream_info_impl::calc_transport_buf_samples(
 
 void stream_info_impl::version(int v) {
 	version_ = v;
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	doc_.child("info").child("version").first_child().set_value(to_string(version_ / 100.));
+#else
 	doc_.child("info").child("version").first_child().set_value(to_string(version_ / 100.).c_str());
+#endif
 }
 
 void stream_info_impl::created_at(double v) {
 	created_at_ = v;
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	doc_.child("info").child("created_at").first_child().set_value(to_string(created_at_));
+#else
 	doc_.child("info").child("created_at").first_child().set_value(to_string(created_at_).c_str());
+#endif
 }
 
 void stream_info_impl::uid(const std::string &v) {
 	uid_ = v;
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	doc_.child("info").child("uid").first_child().set_value(uid_);
+#else
 	doc_.child("info").child("uid").first_child().set_value(uid_.c_str());
+#endif
 }
 
 const std::string& stream_info_impl::reset_uid()
@@ -285,17 +301,29 @@ const std::string& stream_info_impl::reset_uid()
 
 void stream_info_impl::session_id(const std::string &v) {
 	session_id_ = v;
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	doc_.child("info").child("session_id").first_child().set_value(session_id_);
+#else
 	doc_.child("info").child("session_id").first_child().set_value(session_id_.c_str());
+#endif
 }
 
 void stream_info_impl::hostname(const std::string &v) {
 	hostname_ = v;
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	doc_.child("info").child("hostname").first_child().set_value(hostname_);
+#else
 	doc_.child("info").child("hostname").first_child().set_value(hostname_.c_str());
+#endif
 }
 
 void stream_info_impl::v4address(const std::string &v) {
 	v4address_ = v;
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	doc_.child("info").child("v4address").first_child().set_value(v4address_);
+#else
 	doc_.child("info").child("v4address").first_child().set_value(v4address_.c_str());
+#endif
 }
 
 void stream_info_impl::v4data_port(uint16_t v) {
@@ -310,7 +338,11 @@ void stream_info_impl::v4service_port(uint16_t v) {
 
 void stream_info_impl::v6address(const std::string &v) {
 	v6address_ = v;
+#if defined(PUGIXML_HAS_STRING_VIEW)
+	doc_.child("info").child("v6address").first_child().set_value(v6address_);
+#else
 	doc_.child("info").child("v6address").first_child().set_value(v6address_.c_str());
+#endif
 }
 
 void stream_info_impl::v6data_port(uint16_t v) {

--- a/src/stream_info_impl.cpp
+++ b/src/stream_info_impl.cpp
@@ -47,11 +47,7 @@ template <typename T> void append_text_node(xml_node &node, const char *name, co
 }
 
 template <> void append_text_node(xml_node &node, const char *name, const std::string &value) {
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	node.append_child(name).append_child(node_pcdata).set_value(value);
-#else
-	node.append_child(name).append_child(node_pcdata).set_value(value.c_str());
-#endif
 }
 
 void stream_info_impl::write_xml(xml_document &doc) {
@@ -268,29 +264,17 @@ uint32_t lsl::stream_info_impl::calc_transport_buf_samples(
 
 void stream_info_impl::version(int v) {
 	version_ = v;
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	doc_.child("info").child("version").first_child().set_value(to_string(version_ / 100.));
-#else
-	doc_.child("info").child("version").first_child().set_value(to_string(version_ / 100.).c_str());
-#endif
 }
 
 void stream_info_impl::created_at(double v) {
 	created_at_ = v;
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	doc_.child("info").child("created_at").first_child().set_value(to_string(created_at_));
-#else
-	doc_.child("info").child("created_at").first_child().set_value(to_string(created_at_).c_str());
-#endif
 }
 
 void stream_info_impl::uid(const std::string &v) {
 	uid_ = v;
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	doc_.child("info").child("uid").first_child().set_value(uid_);
-#else
-	doc_.child("info").child("uid").first_child().set_value(uid_.c_str());
-#endif
 }
 
 const std::string& stream_info_impl::reset_uid()
@@ -301,29 +285,17 @@ const std::string& stream_info_impl::reset_uid()
 
 void stream_info_impl::session_id(const std::string &v) {
 	session_id_ = v;
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	doc_.child("info").child("session_id").first_child().set_value(session_id_);
-#else
-	doc_.child("info").child("session_id").first_child().set_value(session_id_.c_str());
-#endif
 }
 
 void stream_info_impl::hostname(const std::string &v) {
 	hostname_ = v;
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	doc_.child("info").child("hostname").first_child().set_value(hostname_);
-#else
-	doc_.child("info").child("hostname").first_child().set_value(hostname_.c_str());
-#endif
 }
 
 void stream_info_impl::v4address(const std::string &v) {
 	v4address_ = v;
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	doc_.child("info").child("v4address").first_child().set_value(v4address_);
-#else
-	doc_.child("info").child("v4address").first_child().set_value(v4address_.c_str());
-#endif
 }
 
 void stream_info_impl::v4data_port(uint16_t v) {
@@ -338,11 +310,7 @@ void stream_info_impl::v4service_port(uint16_t v) {
 
 void stream_info_impl::v6address(const std::string &v) {
 	v6address_ = v;
-#if defined(PUGIXML_HAS_STRING_VIEW)
 	doc_.child("info").child("v6address").first_child().set_value(v6address_);
-#else
-	doc_.child("info").child("v6address").first_child().set_value(v6address_.c_str());
-#endif
 }
 
 void stream_info_impl::v6data_port(uint16_t v) {


### PR DESCRIPTION
Close #247

This is a redo of #253 , originally by @myd7349. The only difference is that it is rebased on `dev` after I updated some GHA secrets. Either that, or the fact that this is coming from my account, should bypass the errors related to secret access.

Original text:

I have fixed the compilation error on Ubuntu.

Specifically, this error occurs when `-DLSL_BUNDLED_PUGIXML=OFF` is specified:

https://github.com/sccn/liblsl/blob/63741a91f6461768c5b4e070f6ef8b62069b556d/.github/workflows/cppcmake.yml#L43

pugixml 1.15 added std::string overloads (in fact, std::string_view) for some APIs, but older versions of pugixml do not support them. When liblsl is built against a non-bundled pugixml prior to 1.15, these issues arise. Therefore, to use the new overloads while remaining compatible with older pugixml versions, it is necessary to check whether the `PUGIXML_HAS_STRING_VIEW` macro is defined.

https://github.com/zeux/pugixml/blob/v1.15/src/pugixml.hpp#L445-L447
