### PR TITLE
 Decrease log spam on stream startup

### DIFF
--- a/cmake/ProjectOptions.cmake
+++ b/cmake/ProjectOptions.cmake
@@ -1,7 +1,9 @@
 include(CMakeDependentOption)
 
 # Project build options
-option(LSL_DEBUGLOG "Enable (lots of) additional debug messages" OFF)
+# Default LSL_DEBUGLOG to ON for Debug builds (single-config generators only)
+string(COMPARE EQUAL "${CMAKE_BUILD_TYPE}" "Debug" _LSL_DEBUGLOG_DEFAULT)
+option(LSL_DEBUGLOG "Enable (lots of) additional debug messages" ${_LSL_DEBUGLOG_DEFAULT})
 option(LSL_UNIXFOLDERS "Use the unix folder layout for install targets" ON)
 option(LSL_BUILD_STATIC "Build LSL as a static library." OFF)
 option(LSL_FRAMEWORK "Build LSL as an Apple Framework (Mac only)" ON)

--- a/src/api_config.cpp
+++ b/src/api_config.cpp
@@ -94,7 +94,12 @@ void api_config::load_from_file(const std::string &filename) {
 		}
 
 		// read the [log] settings
-		int log_level = pt.get("log.level", (int)loguru::Verbosity_INFO);
+#if LOGURU_DEBUG_LOGGING
+		// When built with LSL_DEBUGLOG=ON, default to verbose logging
+		int log_level = pt.get("log.level", 1);
+#else
+		int log_level = pt.get("log.level", static_cast<int>(loguru::Verbosity_INFO));
+#endif
 		if (log_level < -3 || log_level > 9)
 			throw std::runtime_error("Invalid log.level (valid range: -3 to 9");
 

--- a/src/netinterfaces.cpp
+++ b/src/netinterfaces.cpp
@@ -86,7 +86,7 @@ std::vector<lsl::netif> lsl::get_local_interfaces() {
 	for (auto *addr = ifs; addr != nullptr; addr = addr->ifa_next) {
 		// No address? Skip.
 		if (addr->ifa_addr == nullptr) continue;
-		LOG_F(INFO, "netif '%s' (status: %d, multicast: %d, broadcast: %d)", addr->ifa_name,
+		LOG_F(1, "netif '%s' (status: %d, multicast: %d, broadcast: %d)", addr->ifa_name,
 			addr->ifa_flags & IFF_UP, addr->ifa_flags & IFF_MULTICAST,
 			addr->ifa_flags & IFF_BROADCAST);
 		// Interface doesn't support multicast? Skip.
@@ -99,10 +99,10 @@ std::vector<lsl::netif> lsl::get_local_interfaces() {
 		if (addr->ifa_addr->sa_family == AF_INET) {
 			if_.addr = asio::ip::make_address_v4(
 				ntohl(reinterpret_cast<sockaddr_in *>(addr->ifa_addr)->sin_addr.s_addr));
-			LOG_F(INFO, "\tIPv4 addr: %x", if_.addr.to_v4().to_uint());
+			LOG_F(1, "\tIPv4 addr: %x", if_.addr.to_v4().to_uint());
 		} else if (addr->ifa_addr->sa_family == AF_INET6) {
 			if_.addr = sinaddr_to_asio(reinterpret_cast<sockaddr_in6 *>(addr->ifa_addr));
-			LOG_F(INFO, "\tIPv6 addr: %s", if_.addr.to_string().c_str());
+			LOG_F(1, "\tIPv6 addr: %s", if_.addr.to_string().c_str());
 		} else
 			continue;
 

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -78,7 +78,7 @@ udp_server::udp_server(stream_info_impl_p info, asio::io_context &io, ip::addres
 				socket_->set_option(
 					ip::multicast::join_group(addr.to_v6(), if_.addr.to_v6().scope_id()), err);
 			if (err)
-				LOG_F(WARNING, "Could not bind multicast responder for %s to interface %s (%s)",
+				LOG_F(1, "Could not bind multicast responder for %s to interface %s (%s)",
 					addr.to_string().c_str(), if_.addr.to_string().c_str(), err.message().c_str());
 			else
 				joined_anywhere = true;


### PR DESCRIPTION
 LOG_F(INFO, ...) and LOG_F(WARNING, ...) → LOG_F(1, ...)

The goal is to eliminate the mostly-uninformative log spam on startup, especially related to ipv6 interfaces not accepting multicast. I've received many questions about these logs -- so it's confusing to users -- and I don't think it's ever helped anyone resolve a problem. They still have some utility for us developers so we should be able to access them in debug mode.