### PR TITLE
Fix logic check for UDP error, handle socket close

### DIFF
--- a/src/stream_outlet_impl.cpp
+++ b/src/stream_outlet_impl.cpp
@@ -57,7 +57,7 @@ stream_outlet_impl::stream_outlet_impl(const stream_info_impl &info, int32_t chu
 	for (const auto &io : {io_ctx_data_, io_ctx_service_})
 		io_threads_.emplace_back(std::make_shared<std::thread>([io, name]() {
 			loguru::set_thread_name(name.c_str());
-			while (true) {
+			while (!io->stopped()) {
 				try {
 					io->run();
 					return;

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -209,6 +209,8 @@ void tcp_server::end_serving() {
 
 void tcp_server::accept_next_connection(tcp_acceptor_p &acceptor) {
 	try {
+		if (!acceptor || !acceptor->is_open()) return;
+
 		// Select the IO context for handling the socket
 		auto &sock_io_ctx = *io_;
 
@@ -223,8 +225,9 @@ void tcp_server::accept_next_connection(tcp_acceptor_p &acceptor) {
 			else
 				LOG_F(WARNING, "Unhandled accept error: %s", err.message().c_str());
 
-			// and move on to the next connection
-			shared_this->accept_next_connection(acceptor);
+			// move on to the next connection if the acceptor is still open
+			if (acceptor && acceptor->is_open())
+				shared_this->accept_next_connection(acceptor);
 		});
 	} catch (std::exception &e) {
 		LOG_F(ERROR, "Error during tcp_server::accept_next_connection: %s", e.what());

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -170,8 +170,9 @@ void udp_server::process_timedata_request(std::istream &request_stream, double t
 void udp_server::handle_receive_outcome(err_t err, std::size_t len) {
 	DLOG_F(6, "udp_server::handle_receive_outcome (%lub)", len);
 	if (err) {
-		// non-critical error? Wait for the next packet
-		if (err != asio::error::operation_aborted && err != asio::error::shut_down)
+		// non-critical error? Wait for the next packet if the socket is still open
+		if (err != asio::error::operation_aborted && err != asio::error::shut_down
+			&& socket_ && socket_->is_open())
 			request_next_packet();
 		return;
 	}

--- a/src/udp_server.cpp
+++ b/src/udp_server.cpp
@@ -171,7 +171,7 @@ void udp_server::handle_receive_outcome(err_t err, std::size_t len) {
 	DLOG_F(6, "udp_server::handle_receive_outcome (%lub)", len);
 	if (err) {
 		// non-critical error? Wait for the next packet
-		if (err != asio::error::operation_aborted || err != asio::error::shut_down)
+		if (err != asio::error::operation_aborted && err != asio::error::shut_down)
 			request_next_packet();
 		return;
 	}


### PR DESCRIPTION
This fix prevents `request_next_packet()` being called when there is an `asio::error::operation_aborted` or `asio::error::shut_down`.

previously, this would always return true even if the error was one of the above because of the or/`||` 

There are also additional checks in the TCP/UDP server and stream outlet to (hopefully) more gracefully handle socket closure.

may address https://github.com/sccn/liblsl/issues/199
I have experienced a segfault when switching networks on Windows and MacOS (I am primarily using Linux now but I haven't tried disconnecting an interface to see if it reproduces)