### PR TITLE
Fix lsl_get_channel_bytes to return 0 for cft_string as documented

### DIFF
--- a/src/stream_info_impl.cpp
+++ b/src/stream_info_impl.cpp
@@ -243,7 +243,7 @@ bool query_cache::matches_query(const xml_document &doc, const std::string &quer
 }
 
 int stream_info_impl::channel_bytes() const {
-	const int channel_format_sizes[] = {0, sizeof(float), sizeof(double), sizeof(std::string),
+	const int channel_format_sizes[] = {0, sizeof(float), sizeof(double), 0,
 		sizeof(int32_t), sizeof(int16_t), sizeof(int8_t), 8};
 	return channel_format_sizes[channel_format_];
 }


### PR DESCRIPTION
The documentation for `lsl_get_channel_bytes` states that it returns 0 for the string type (`cft_string`), but in practice this is not the case:

https://github.com/sccn/liblsl/blob/cdf917d0936d4fc03c4367de8be40347b449e64e/include/lsl/streaminfo.h#L174-L175

This patch fixes the issue by returning 0 for the string type.
