### PR TITLE
Feature/fix fullinfo error code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .idea/
 /cmake-build-*/
 /examples/build*/
+.vscode/

--- a/src/lsl_inlet_c.cpp
+++ b/src/lsl_inlet_c.cpp
@@ -36,6 +36,7 @@ LIBLSL_C_API void lsl_destroy_inlet(lsl_inlet in) {
 }
 
 LIBLSL_C_API lsl_streaminfo lsl_get_fullinfo(lsl_inlet in, double timeout, int32_t *ec) {
+	if (ec) *ec = lsl_no_error;
 	try {
 		return new stream_info_impl(in->info(timeout));
 	}


### PR DESCRIPTION
There is an issue with getting a stream `fullinfo`.

Because EC is not initialized with `lsl_no_error` the value of `ec` can be undefined, resulting in checks of `ec` incorrectly reporting that there was an error `ec != 0`.

This just adds the same initialization that exists in other functions that use `ec`