### PR TITLE
Prefer system-provided library for Catch2 

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -9,14 +9,16 @@ include(GNUInstallDirs)
 
 option(LSL_BENCHMARKS "Enable benchmarks in unit tests" OFF)
 
-
-Include(FetchContent)
-FetchContent_Declare(
-		Catch2
-		GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-		GIT_TAG        v3.4.0 # or a later release
-)
-FetchContent_MakeAvailable(Catch2)
+find_package(Catch2 3 CONFIG QUIET)
+if(NOT TARGET Catch2::Catch2)
+	include(FetchContent)
+	FetchContent_Declare(
+			Catch2
+			GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+			GIT_TAG        v3.4.0 # or a later release
+	)
+	FetchContent_MakeAvailable(Catch2)
+endif()
 
 
 add_library(catch_main OBJECT catch_main.cpp)

--- a/testing/int/postproc.cpp
+++ b/testing/int/postproc.cpp
@@ -3,7 +3,7 @@
 #include <random>
 #include <thread>
 // include loguru before catch
-#include <catch2/catch_approx.cpp>
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 // clazy:excludeall=non-pod-global-static


### PR DESCRIPTION
For distro packages it is prefereable to use system-provided packages. Use the system-provided library if available.