### PR TITLE
Allow UID to be reset via C API (extends #260)

### DIFF
--- a/include/lsl/streaminfo.h
+++ b/include/lsl/streaminfo.h
@@ -126,6 +126,14 @@ extern LIBLSL_C_API double lsl_get_created_at(lsl_streaminfo info);
 extern LIBLSL_C_API const char *lsl_get_uid(lsl_streaminfo info);
 
 /**
+ * Reset the UID of the stream info to a new random value.
+ *
+ * This can be used to generate a UID if one doesn't exist.
+ * @return An immutable library-owned pointer to the new string value. @sa lsl_destroy_string()
+ */
+extern LIBLSL_C_API const char *lsl_reset_uid(lsl_streaminfo info);
+
+/**
  * Session ID for the given stream.
  *
  * The session id is an optional human-assigned identifier of the recording session.

--- a/include/lsl_cpp.h
+++ b/include/lsl_cpp.h
@@ -289,6 +289,15 @@ public:
 	std::string uid() const { return lsl_get_uid(obj.get()); }
 
 	/**
+	 * Reset the unique ID of the stream to a new random value.
+	 *
+	 * This can be used to assign a UID to a stream_info that does not yet have one (e.g., one
+	 * constructed locally and not obtained from an inlet).
+	 * @return The new UID.
+	 */
+	std::string reset_uid() { return lsl_reset_uid(obj.get()); }
+
+	/**
 	 * Session ID for the given stream.
 	 *
 	 * The session id is an optional human-assigned identifier of the recording session.

--- a/src/lsl_streaminfo_c.cpp
+++ b/src/lsl_streaminfo_c.cpp
@@ -49,6 +49,10 @@ LIBLSL_C_API const char *lsl_get_source_id(lsl_streaminfo info) {
 LIBLSL_C_API int32_t lsl_get_version(lsl_streaminfo info) { return info->version(); }
 LIBLSL_C_API double lsl_get_created_at(lsl_streaminfo info) { return info->created_at(); }
 LIBLSL_C_API const char *lsl_get_uid(lsl_streaminfo info) { return info->uid().c_str(); }
+LIBLSL_C_API const char *lsl_reset_uid(lsl_streaminfo info) {
+	return info->reset_uid().c_str();
+	
+}
 LIBLSL_C_API const char *lsl_get_session_id(lsl_streaminfo info) {
 	return info->session_id().c_str();
 }

--- a/src/lsl_streaminfo_c.cpp
+++ b/src/lsl_streaminfo_c.cpp
@@ -49,10 +49,7 @@ LIBLSL_C_API const char *lsl_get_source_id(lsl_streaminfo info) {
 LIBLSL_C_API int32_t lsl_get_version(lsl_streaminfo info) { return info->version(); }
 LIBLSL_C_API double lsl_get_created_at(lsl_streaminfo info) { return info->created_at(); }
 LIBLSL_C_API const char *lsl_get_uid(lsl_streaminfo info) { return info->uid().c_str(); }
-LIBLSL_C_API const char *lsl_reset_uid(lsl_streaminfo info) {
-	return info->reset_uid().c_str();
-	
-}
+LIBLSL_C_API const char *lsl_reset_uid(lsl_streaminfo info) { return info->reset_uid().c_str(); }
 LIBLSL_C_API const char *lsl_get_session_id(lsl_streaminfo info) {
 	return info->session_id().c_str();
 }


### PR DESCRIPTION
Extends #260 by @zeyus, which exposes the existing `stream_info_impl::reset_uid()` through the C API. Useful for generating a UID on a locally-constructed `stream_info` that has not yet been associated with an inlet.

This PR keeps @zeyus's original commit and adds a small follow-up commit:

- Collapse the `lsl_reset_uid` C wrapper to the one-line style of its siblings and drop a stray blank line.
- Add a matching `stream_info::reset_uid()` wrapper to `include/lsl_cpp.h` for C++/C API parity.

Verified locally on macOS: configures and builds, and `_lsl_reset_uid` is present in the exported symbols of the shared library.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)