### PR TITLE
Fix lsl_get_channel_bytes to return 0 for cft_string as documented (extends #261)

### DIFF
--- a/src/stream_info_impl.cpp
+++ b/src/stream_info_impl.cpp
@@ -243,7 +243,7 @@ bool query_cache::matches_query(const xml_document &doc, const std::string &quer
 }
 
 int stream_info_impl::channel_bytes() const {
-	const int channel_format_sizes[] = {0, sizeof(float), sizeof(double), sizeof(std::string),
+	const int channel_format_sizes[] = {0, sizeof(float), sizeof(double), 0,
 		sizeof(int32_t), sizeof(int16_t), sizeof(int8_t), 8};
 	return channel_format_sizes[channel_format_];
 }

--- a/testing/int/tcpserver.cpp
+++ b/testing/int/tcpserver.cpp
@@ -3,6 +3,7 @@
 #include "send_buffer.h"
 #include "stream_info_impl.h"
 #include "tcp_server.h"
+#include "util/endian.hpp"
 #include <asio/read.hpp>
 #include <asio/read_until.hpp>
 #include <asio/write.hpp>
@@ -138,10 +139,15 @@ TEST_CASE("tcpserver", "[network]") {
 			cmp_binstr(expected, received_pattern);
 		}));
 
+	// String channels report a per-channel value size of 0 (channel_bytes() == 0), so the server
+	// performs no endian conversion and advertises its own (host) byte order regardless of the
+	// client's request. Any needed swapping of the string length-prefixes happens on the receiving
+	// side instead (see tcpserver_float for the actual binary endian-conversion test).
 	send_request(ctx, ep, asio::buffer("LSL:streamfeed/199 \nNative-byte-order:4321\r\n\r\n"),
 		with_read_callback("endian", [](const std::string &res) {
 			REQUIRE(res.substr(0, 14) == "LSL/110 200 OK");
-			REQUIRE(res.find("Byte-Order: 4321") != std::string::npos);
+			REQUIRE(res.find("Byte-Order: " + std::to_string(static_cast<int>(lsl::LSL_BYTE_ORDER))) !=
+					std::string::npos);
 		}));
 
 	send_request(ctx, ep, asio::buffer("LSL:streamfeed\n0 0\r\n"),


### PR DESCRIPTION
Extends #261 by @myd7349. `lsl_get_channel_bytes` is documented to return 0 for the string type (`cft_string`), and the wire protocol already assumes this — `data_receiver.cpp` literally annotates the `Value-Size` header with `// 0 for strings`. In practice it was returning the (platform-dependent) `sizeof(std::string)` instead. This restores the documented contract.

## Why the abandoned endian test failure is expected, not a regression

@myd7349 paused this PR because the `tcpserver` string `endian` test failed. I traced it: the server's default `client_value_size` comes from `channel_bytes()`. With the fix it's 0 for strings, so the server no longer volunteers an endian conversion (`value_size > 1` is false) and advertises its own host byte order instead of echoing the client's `4321`.

This is **not** a data-path regression:
- The actual per-sample string serialization uses the separate `format_sizes[]` array in `sample.h` (unchanged here), so string length-prefixes are still byte-swapped when needed.
- The receiver independently re-derives whether to swap from the advertised `Byte-Order` header (`data_receiver.cpp`). The fix only shifts *which side* swaps the length-prefixes; all cross-endian / cross-version combinations remain correct.

## Changes

- @myd7349's one-line fix to `channel_bytes()`.
- Follow-up commit: update the `tcpserver` string `endian` subtest to assert the server advertises its host byte order (no reversal for strings). The float case (`tcpserver_float`) still covers actual binary endian conversion.

Verified locally on macOS: `lsl_test_internal` (310 assertions) and `lsl_test_exported` (724 assertions) all pass.

Closes #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)