### PR TITLE
Resolve all same-machine streams (fix the 127.0.0.1 unicast lottery)

### DIFF
--- a/src/api_config.cpp
+++ b/src/api_config.cpp
@@ -262,6 +262,18 @@ void api_config::load(INI &pt) {
 			multicast_addresses_.push_back(addr);
 	}
 
+	// Parse and store the machine-local (loopback/unicast) addresses separately. They are also
+	// part of multicast_addresses_, but because a unicast datagram to the shared multicast_port is
+	// delivered to only one of the sockets bound there, the resolver must additionally probe these
+	// across the per-stream service-port range to reach every local stream (see resolver_impl).
+	for (auto &it : machine_group) {
+		try {
+			ip::address addr = ip::make_address(it);
+			if ((addr.is_v4() && allow_ipv4_) || (addr.is_v6() && allow_ipv6_))
+				machine_addresses_.push_back(addr);
+		} catch (std::exception &) {}
+	}
+
 	// The network stack requires the source interfaces for multicast packets to be
 	// specified as IPv4 address or an IPv6 interface index
 	// Try getting the interfaces from the configuration files

--- a/src/api_config.h
+++ b/src/api_config.h
@@ -135,6 +135,18 @@ public:
 	const std::vector<ip::address> &multicast_addresses() const { return multicast_addresses_; }
 
 	/**
+	 * @brief The machine-local (loopback/unicast) addresses from multicast.MachineAddresses.
+	 *
+	 * These are a subset of multicast_addresses() but, being unicast, a datagram sent to them
+	 * at the shared multicast_port is delivered to only one of the responder sockets bound there
+	 * (the "unicast lottery" — only one local stream answers, depending on bind order). The
+	 * resolver therefore additionally probes these addresses across the per-stream service-port
+	 * range [base_port, base_port+port_range), where each stream owns a unique socket, so every
+	 * local stream is discoverable regardless of bind order.
+	 */
+	const std::vector<ip::address> &machine_addresses() const { return machine_addresses_; }
+
+	/**
 	 * @brief The address of the local interface on which to listen to multicast traffic.
 	 *
 	 * The default is an empty string, i.e. bind to the default interface(s).
@@ -277,6 +289,7 @@ private:
 	uint16_t multicast_port_;
 	std::string resolve_scope_;
 	std::vector<ip::address> multicast_addresses_;
+	std::vector<ip::address> machine_addresses_;
 	int multicast_ttl_;
 	std::string listen_address_;
 	std::vector<std::string> known_peers_;

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -46,6 +46,16 @@ resolver_impl::resolver_impl()
 		} catch (std::exception &) {}
 	}
 
+	// Machine-local addresses (e.g. 127.0.0.1) are multicast targets too, but a unicast datagram
+	// to the shared multicast_port is delivered to only one of the responder sockets bound there
+	// (the "unicast lottery"): only one local stream answers, and which one depends on bind order.
+	// Probe them across the per-stream service-port range as well, where every stream owns a unique
+	// socket, so all local streams are discoverable regardless of bind order.
+	for (const auto &addr : cfg_->machine_addresses()) {
+		for (int p = cfg_->base_port(); p < cfg_->base_port() + cfg_->port_range(); p++)
+			ucast_endpoints_.emplace_back(addr, p);
+	}
+
 	// generate the list of protocols to use
 	if (cfg_->allow_ipv6()) {
 		udp_protocols_.push_back(udp::v6());

--- a/src/resolver_impl.cpp
+++ b/src/resolver_impl.cpp
@@ -6,6 +6,7 @@
 #include <asio/io_context.hpp>
 #include <asio/ip/basic_resolver.hpp>
 #include <asio/ip/udp.hpp>
+#include <algorithm>
 #include <exception>
 #include <loguru.hpp>
 #include <memory>
@@ -55,6 +56,17 @@ resolver_impl::resolver_impl()
 		for (int p = cfg_->base_port(); p < cfg_->base_port() + cfg_->port_range(); p++)
 			ucast_endpoints_.emplace_back(addr, p);
 	}
+
+	// The same endpoint can be enqueued more than once (e.g. a machine address that also appears in
+	// KnownPeers, or a repeated config entry). Drop duplicates so we don't send identical queries to
+	// the same socket. This is distinct from the UID-based dedup of *results*: two different
+	// endpoints can still return the same stream (e.g. its multicast_port and its service port).
+	auto dedupe = [](std::vector<udp::endpoint> &eps) {
+		std::sort(eps.begin(), eps.end());
+		eps.erase(std::unique(eps.begin(), eps.end()), eps.end());
+	};
+	dedupe(mcast_endpoints_);
+	dedupe(ucast_endpoints_);
 
 	// generate the list of protocols to use
 	if (cfg_->allow_ipv6()) {

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -107,6 +107,17 @@ add_executable(lsl_test_runtime_config int/runtime_config.cpp)
 target_link_libraries(lsl_test_runtime_config PRIVATE lslobj lslboost common catch_main)
 target_compile_definitions(lsl_test_runtime_config PRIVATE LIBLSL_EXPORTS)
 
+# resolve_machine test sets the api_config singleton, so it lives in its own executable.
+add_executable(lsl_test_resolve_machine int/resolve_machine.cpp)
+target_link_libraries(lsl_test_resolve_machine PRIVATE lslobj lslboost common catch_main)
+target_compile_definitions(lsl_test_resolve_machine PRIVATE LIBLSL_EXPORTS)
+# Needs pugixml headers (resolver_impl.h -> stream_info_impl.h includes pugixml)
+if(LSL_PUGIXML_IS_FETCHED)
+    target_include_directories(lsl_test_resolve_machine PRIVATE ${pugixml_SOURCE_DIR}/src)
+else()
+    target_link_libraries(lsl_test_resolve_machine PRIVATE pugixml::pugixml)
+endif()
+
 if(LSL_BENCHMARKS)
 	# to get somewhat reproducible performance numbers:
 	# /usr/bin/time -v testing/lsl_test_exported --benchmark-samples 100  bounce
@@ -122,7 +133,7 @@ if(LSL_BENCHMARKS)
 	)
 endif()
 
-set(LSL_TESTS lsl_test_exported lsl_test_internal lsl_test_runtime_config)
+set(LSL_TESTS lsl_test_exported lsl_test_internal lsl_test_runtime_config lsl_test_resolve_machine)
 foreach(lsltest ${LSL_TESTS})
 	add_test(NAME ${lsltest} COMMAND ${lsltest} --wait-for-keypress never)
 	if(LSL_INSTALL)

--- a/testing/int/resolve_machine.cpp
+++ b/testing/int/resolve_machine.cpp
@@ -1,0 +1,45 @@
+#include "api_config.h"
+#include <catch2/catch_test_macros.hpp>
+#include <lsl_cpp.h>
+#include <string>
+#include <vector>
+
+// Regression test for the same-machine "unicast lottery" (only one local stream resolves).
+//
+// With ResolveScope=machine the only discovery target is the machine address (127.0.0.1) at the
+// shared multicast_port. That port is unicast, not multicast, so a query datagram is delivered to
+// exactly one of the responder sockets bound there — only one outlet answers, and which one
+// depends on bind order. Several outlets are therefore created, but pre-fix only one is found.
+//
+// The fix additionally probes the machine addresses across the per-stream service-port range,
+// where every outlet owns a unique socket, so all of them are discoverable.
+//
+// Sets the api_config singleton, so (like runtime_config) it lives in its own executable.
+
+TEST_CASE("all same-machine streams resolve under ResolveScope=machine", "[resolver][machine]") {
+	lsl::api_config::set_api_config_content(
+		"[ports]\n"
+		"IPv6 = disable\n"
+		"[multicast]\n"
+		"ResolveScope = machine\n"
+		"MachineAddresses = {127.0.0.1}\n"
+		"[lab]\n"
+		"SessionID = resolve_machine_test\n"
+		"KnownPeers = {}\n"); // no KnownPeers: discovery relies solely on the machine address
+
+	// Stand up several outlets on this machine. Each binds its own per-stream service port.
+	constexpr int n = 3;
+	std::vector<lsl::stream_outlet> outlets;
+	outlets.reserve(n);
+	for (int i = 0; i < n; i++) {
+		lsl::stream_info info("machtest" + std::to_string(i), "machtest", 1, lsl::IRREGULAR_RATE,
+			lsl::cf_float32, "machsrc" + std::to_string(i));
+		outlets.emplace_back(info);
+	}
+
+	// Resolve by the shared type. Pre-fix the unicast lottery yields fewer than n; the fix probes
+	// each outlet's unique service port, so all n are found.
+	std::vector<lsl::stream_info> found = lsl::resolve_stream("type", "machtest", n, 5.0);
+
+	CHECK(found.size() == n);
+}


### PR DESCRIPTION
## Summary

Fixes the long-standing "only one of my local streams shows up, and which one shuffles when I restart things" failure. Same-machine discovery relied solely on a unicast query to the shared `multicast_port` (`127.0.0.1:16571`); the fix additionally probes the machine-local addresses across the per-stream service-port range, where every stream owns a unique socket.

## Root cause

`MachineAddresses` (default `{127.0.0.1}`) is folded into the multicast address list and queried only at `multicast_port` (16571). But `127.0.0.1` is a **unicast** address, not a multicast group: the OS delivers a datagram sent to a shared port to **only one** of the responder sockets bound there. So when several outlets run on a machine, only one answers a discovery query, and which one depends on socket bind order. Restarting programs shuffles which stream is visible.

This is the mechanism behind a cluster of reports: #28 (Azure macOS, only one stream resolves — diagnosed in-thread as exactly this), #92 (the issue literally titled "Remove 127.0.0.1 from multicast addresses"), #202 (Windows→Linux, order-dependent), and #207 (Android, only one stream when no Wi-Fi/loopback only).

## Fix

In addition to the `16571` query, probe each machine-local address across the per-stream service-port range `[base_port, base_port+port_range)` (16572–16603), where each outlet binds its own unique socket and answers `LSL:shortinfo`. This mirrors how `KnownPeers` are already sprayed and needs **no OS routing changes**.

- `api_config`: parse and expose `machine_addresses()` (the unicast subset of `multicast.MachineAddresses`).
- `resolver_impl`: add those addresses to the unicast target list in the resolver's constructor.

`127.0.0.1` is intentionally left in the multicast list too (covered redundantly and harmlessly at 16571), so there is no behavior change for setups that relied on it, and #92's "remove 127.0.0.1 + add a loopback multicast route" workaround is no longer needed.

## Test

New `lsl_test_resolve_machine` (own executable, like `runtime_config`, since it sets the `api_config` singleton): under `ResolveScope=machine` it stands up 3 local outlets and asserts all 3 resolve. Pre-fix this fails deterministically as `1 == 3` (the lottery); post-fix all are found.

## Testing

Full suite green locally (macOS universal): new test passes; `discovery` (live UDP resolution, 724 assertions), `network`, `tcpserver`, `streaminfo`, and `runtime_config` are unaffected by the now-default loopback unicast wave.

## Scope / relationship

- Wire protocol, API, and config defaults unchanged — only adds extra local unicast probe targets.
- Independent of #278 (firewall asymmetry) and #279 (TCP fallback), and of the sibling PR fixing a bad-multicast-interface crash. All touch the resolver subsystem but the changes don't overlap.