### PR TITLE
tests: make the tcpserver test big-endian clean

### DIFF
--- a/testing/int/tcpserver.cpp
+++ b/testing/int/tcpserver.cpp
@@ -8,6 +8,7 @@
 #include <asio/read_until.hpp>
 #include <asio/write.hpp>
 #include <catch2/catch_all.hpp>
+#include <algorithm>
 #include <functional>
 #include <sstream>
 #include <thread>
@@ -94,7 +95,11 @@ auto with_read_callback(const char *name, std::function<void(const std::string &
 void check_streamfeed_100_response(const std::string &res) {
 	REQUIRE(res.substr(0, 4) == "\x7f\x01\x09\2");
 	INFO(bytes_to_hexstr(res.substr(0, 10)));
-	auto info_len = *reinterpret_cast<const uint16_t*>(res.data() + 4);
+	// The portable binary archive serializes integers little-endian on the wire, so decode
+	// the 2-byte info-length prefix explicitly instead of via a host-order load (which would
+	// read it byte-swapped on big-endian hosts).
+	const auto *lenp = reinterpret_cast<const unsigned char *>(res.data() + 4);
+	uint16_t info_len = static_cast<uint16_t>(lenp[0] | (lenp[1] << 8));
 
 	REQUIRE(static_cast<int>(res.size()) > 6 + info_len);
 
@@ -134,8 +139,13 @@ TEST_CASE("tcpserver", "[network]") {
 			auto endofheader = res.find("\r\n\r\n");
 			REQUIRE(endofheader != std::string::npos);
 			std::string received_pattern = res.substr(endofheader + 4);
-			std::string expected = "\2" TESTPAT_TIMESTAMP TESTPAT_STR;
-			expected += expected;
+			// String streams carry zero-size values, so the server applies no endian
+			// conversion and emits the timestamp double in host byte order. TESTPAT_TIMESTAMP
+			// is the little-endian encoding; byte-reverse it on big-endian hosts.
+			std::string ts = TESTPAT_TIMESTAMP;
+			if (lsl::LSL_BYTE_ORDER == lsl::LSL_BIG_ENDIAN) std::reverse(ts.begin(), ts.end());
+			std::string sample = "\2" + ts + std::string(TESTPAT_STR, sizeof(TESTPAT_STR) - 1);
+			std::string expected = sample + sample;
 			cmp_binstr(expected, received_pattern);
 		}));
 


### PR DESCRIPTION
The tcpserver unit test hard-codes little-endian byte patterns and reads a wire length prefix through a host-order pointer cast, so it fails on big-endian hosts (e.g. s390x). The library itself is endian-correct; only the test fixtures assume a little-endian host.

This patch contains two fixes:

 * check_streamfeed_100_response() reads the 2-byte info-length prefix of the portable binary archive via *reinterpret_cast<const uint16_t*>. The portable archive always serialises integers little-endian on the wire, so on a big-endian host this reads the length byte-swapped (e.g. 0x7102 instead of 0x0271), making the subsequent size check fail. Decode the two bytes explicitly as little-endian instead.

 * The "basic" string-channel case compares against TESTPAT_TIMESTAMP, the little-endian encoding of the timestamp double. String streams carry zero-size values, so the server performs no endian conversion and emits the timestamp in host byte order; the expected pattern must therefore be byte-reversed on big-endian hosts.

No behavioural changes on little-endian hosts.