### PR TITLE
inlet: fix bad_weak_ptr abort during inlet destruction

### DIFF
--- a/src/inlet_connection.cpp
+++ b/src/inlet_connection.cpp
@@ -76,6 +76,20 @@ inlet_connection::inlet_connection(const stream_info_impl &info, bool recover)
 	}
 }
 
+inlet_connection::~inlet_connection() {
+	try {
+		{
+			std::lock_guard<std::mutex> lock(shutdown_mut_);
+			shutdown_ = true;
+		}
+		shutdown_cond_.notify_all();
+		resolver_.cancel();
+	} catch (std::exception &e) {
+		LOG_F(ERROR, "Error during inlet_connection teardown: %s", e.what());
+	}
+	if (watchdog_thread_.joinable()) watchdog_thread_.join();
+}
+
 void inlet_connection::engage() {
 	if (recovery_enabled_) watchdog_thread_ = std::thread(&inlet_connection::watchdog_thread, this);
 }

--- a/src/inlet_connection.h
+++ b/src/inlet_connection.h
@@ -58,6 +58,10 @@ public:
 	 */
 	inlet_connection(const stream_info_impl &info, bool recover = true);
 
+	/// Destructor: signals shutdown and joins the watchdog thread if it is still running
+	/// (e.g., when disengage() did not complete).
+	~inlet_connection() override;
+
 	/**
 	 * Prepare the connection and its auto-recovery thread.
 	 *

--- a/src/resolve_attempt_udp.cpp
+++ b/src/resolve_attempt_udp.cpp
@@ -87,7 +87,11 @@ void resolve_attempt_udp::begin() {
 }
 
 void resolve_attempt_udp::cancel() {
-	post(io_, [shared_this = shared_from_this()]() { shared_this->do_cancel(); });
+	// the attempt is owned by its pending handler chains; between construction and begin() or
+	// after the last handler has completed it has no shared owner and there is nothing to cancel
+	try {
+		post(io_, [shared_this = shared_from_this()]() { shared_this->do_cancel(); });
+	} catch (const std::bad_weak_ptr &) {}
 }
 
 


### PR DESCRIPTION
Fixes the intermittent `std::bad_weak_ptr` → `std::terminate/SIGABRT` on inlet destruction reported in #220: `resolve_attempt_udp::cancel()` calls `shared_from_this()` on an attempt that has no live shared owner, and the exception skips the watchdog `join()`, leaving `~inlet_connection` to destroy a joinable `std::thread`. #220 was closed by #246, but #246 only fixes the outlet-side garbage-sample bug (`consumer_queue.h` / `tcp_server.cpp`) and never touches the inlet resolver-cancellation path, so the crash still reproduces on current main.

Those changes have been suggested by Claude (Fable) following digging in a CI failure on https://github.com/mne-tools/mne-lsl/pull/565. This changes are outside my expertise and comfort zone, thus up to you to merge or iterate on those changes.