### PR TITLE
fix: allocate output values only after success

### DIFF
--- a/include/lsl/inlet.h
+++ b/include/lsl/inlet.h
@@ -169,13 +169,23 @@ extern LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, int64_t *buffer, int3
 extern LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, int16_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
+/**
+ * @note If this function returns a nonzero time stamp, call lsl_destroy_string()
+ * for each string in @p buffer.
+ * If no sample is available, this function does not modify @p buffer.
+ */
 extern LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int32_t buffer_elements, double timeout, int32_t *ec);
 ///@}
 
 /** @copydoc lsl_pull_sample_f
  * These strings may contains 0's, therefore the lengths are read into the buffer_lengths array.
  * @param buffer_lengths
- * A pointer to an array that holds the resulting lengths for each returned binary string.*/
+ * A pointer to an array that holds the resulting lengths for each returned binary string.
+ * @note If this function returns a nonzero time stamp, call lsl_destroy_string()
+ * for each string in @p buffer.
+ * If no sample is available, this function does not modify @p buffer or
+ * @p buffer_lengths.
+ */
 extern LIBLSL_C_API double lsl_pull_sample_buf(lsl_inlet in, char **buffer, uint32_t *buffer_lengths, int32_t buffer_elements, double timeout, int32_t *ec);
 
 /**

--- a/src/lsl_inlet_c.cpp
+++ b/src/lsl_inlet_c.cpp
@@ -124,6 +124,7 @@ LIBLSL_C_API double lsl_pull_sample_str(
 		// capture output in a temporary string buffer
 		std::vector<std::string> tmp;
 		double result = in->pull_sample(tmp, timeout);
+		if (result == 0.0) return result;
 		if (buffer_elements < (int)tmp.size())
 			throw std::range_error(
 				"The provided buffer has fewer elements than the stream's number of channels.");
@@ -150,6 +151,7 @@ LIBLSL_C_API double lsl_pull_sample_buf(lsl_inlet in, char **buffer, uint32_t *b
 		// capture output in a temporary string buffer
 		std::vector<std::string> tmp;
 		double result = in->pull_sample(tmp, timeout);
+		if (result == 0.0) return result;
 		if (buffer_elements < (int)tmp.size())
 			throw std::range_error(
 				"The provided buffer has fewer elements than the stream's number of channels.");

--- a/testing/ext/DataType.cpp
+++ b/testing/ext/DataType.cpp
@@ -60,6 +60,26 @@ TEST_CASE("data datatransfer", "[datatransfer][multi][string]") {
 		FAIL("Sent large string data doesn't match received data");
 }
 
+TEST_CASE("string pull timeout preserves output", "[datatransfer][string]") {
+	constexpr std::size_t num_channels = 2;
+	auto sp = create_streampair(lsl::stream_info(
+		"string_timeout", "DataType", num_channels, lsl::IRREGULAR_RATE, lsl::cf_string, "string_timeout"));
+	char sentinel;
+	char *values[num_channels] = {&sentinel, &sentinel};
+	uint32_t lengths[num_channels] = {1, 1};
+	int32_t ec = lsl_no_error;
+
+	CHECK(lsl_pull_sample_str(sp.in_.handle().get(), values, num_channels, 0.0, &ec) == 0.0);
+	CHECK(values[0] == &sentinel);
+	CHECK(values[1] == &sentinel);
+	CHECK(lsl_pull_sample_buf(
+			  sp.in_.handle().get(), values, lengths, num_channels, 0.0, &ec) == 0.0);
+	CHECK(values[0] == &sentinel);
+	CHECK(values[1] == &sentinel);
+	CHECK(lengths[0] == 1);
+	CHECK(lengths[1] == 1);
+}
+
 TEST_CASE("TypeConversion", "[datatransfer][types][basic]") {
 	Streampair sp{create_streampair(
 		lsl::stream_info("TypeConversion", "int2str2int", 1, 1, lsl::cf_string, "TypeConversion"))};


### PR DESCRIPTION
A timeout path allocates output memory when the function returns no sample.

This change preserves caller output when a string pull times out.

Closes #275.
