### PR TITLE
Fix stack recursion on udp resolve

### DIFF
--- a/src/resolve_attempt_udp.cpp
+++ b/src/resolve_attempt_udp.cpp
@@ -159,39 +159,49 @@ void resolve_attempt_udp::handle_receive_outcome(err_t err, std::size_t len) {
 
 void resolve_attempt_udp::send_next_query(
 	endpoint_list::const_iterator next, mcast_interface_list::const_iterator mcit) {
-	if (cancelled_ || mcit == multicast_interfaces.end()) return;
-	auto proto = recv_socket_.local_endpoint().protocol();
-	if (next == targets_.begin()) {
-		// Mismatching protocols? Skip this round
-		if (mcit->addr.is_v4() != (proto == asio::ip::udp::v4()))
-			next = targets_.end();
-		else
-			multicast_socket_.set_option(mcit->addr.is_v4() ? outbound_interface(mcit->addr.to_v4())
-															: outbound_interface(mcit->ifindex));
-	}
-	if (next != targets_.end()) {
+	const auto proto = recv_socket_.local_endpoint().protocol();
+
+	while (true) {
+		if (cancelled_ || mcit == multicast_interfaces.end()) return;
+
+		if (next == targets_.begin()) {
+			// Mismatching protocols? Skip this round
+			if (mcit->addr.is_v4() != (proto == asio::ip::udp::v4()))
+				next = targets_.end();
+			else
+				multicast_socket_.set_option(mcit->addr.is_v4()
+						? outbound_interface(mcit->addr.to_v4())
+						: outbound_interface(mcit->ifindex));
+		}
+
+		if (next == targets_.end()) {
+			// Restart from the next interface
+			next = targets_.begin();
+			++mcit;
+			continue;
+		}
+
 		udp::endpoint ep(*next++);
 		// endpoint matches our active protocol?
-		if (ep.protocol() == recv_socket_.local_endpoint().protocol()) {
-			// select socket to use
-			udp_socket &sock =
-				(ep.address() == asio::ip::address_v4::broadcast())
-					? broadcast_socket_
-					: (ep.address().is_multicast() ? multicast_socket_ : unicast_socket_);
-			// and send the query over it
-			auto keepalive(shared_from_this());
-			sock.async_send_to(asio::buffer(query_msg_), ep,
-				[shared_this = shared_from_this(), next, mcit](err_t err, size_t /*unused*/) {
-					if (!shared_this->cancelled_ && err != asio::error::operation_aborted &&
-						err != asio::error::not_connected && err != asio::error::not_socket)
-						shared_this->send_next_query(next, mcit);
-				});
-		} else
+		if (ep.protocol() != proto)
 			// otherwise just go directly to the next query
-			send_next_query(next, mcit);
-	} else
-		// Restart from the next interface
-		send_next_query(targets_.begin(), ++mcit);
+			continue;
+
+		// select socket to use
+		udp_socket &sock =
+			(ep.address() == asio::ip::address_v4::broadcast())
+				? broadcast_socket_
+				: (ep.address().is_multicast() ? multicast_socket_ : unicast_socket_);
+		// and send the query over it
+		auto keepalive(shared_from_this());
+		sock.async_send_to(asio::buffer(query_msg_), ep,
+			[shared_this = shared_from_this(), next, mcit](err_t err, size_t /*unused*/) {
+				if (!shared_this->cancelled_ && err != asio::error::operation_aborted &&
+					err != asio::error::not_connected && err != asio::error::not_socket)
+					shared_this->send_next_query(next, mcit);
+			});
+		return;
+	}
 }
 
 void resolve_attempt_udp::do_cancel() {


### PR DESCRIPTION
Often I came across an issue when doing some testing that freezes the entire network stack when using liblsl with a lot of inlets / outlets and a larger portrange (e.g. 128) on my local machine, both in Linux and MacOS.

I think the problem is a combination of number of ports, number of interfaces (I have too many, uni VPNs, VMs, etc), and clients - especially when running locally testing multiple nodes.

This patch keeps the `void resolve_attempt_udp::send_next_query` method a shallow loop rather than becoming recursive, and seems to fix the problem.

I ran a set of tests using my dart bindings with the patch and unpatched version and you can see that the patched version doesn't change the number of calls which unfortunately goes up with the number of ports (as expected), but there's a huge difference in the recursion depth.

```text
                    max_depth                                         max_stack_bytes
                        count  mean    std  min  25%  50%  75%    max           count     mean       std  min  25%  50%    75%       max
portRange status
16        patched       516.0  1.00   0.00  1.0  1.0  1.0  1.0    1.0           516.0     0.00      0.00  0.0  0.0  0.0    0.0       0.0
          unpatched     516.0  3.05  15.28  1.0  1.0  1.0  2.0  175.0           516.0  1051.78   7822.88  0.0  0.0  0.0  512.0   89088.0
32        patched       768.0  1.00   0.00  1.0  1.0  1.0  1.0    1.0           768.0     0.00      0.00  0.0  0.0  0.0    0.0       0.0
          unpatched     769.0  3.21  24.04  1.0  1.0  1.0  1.0  335.0           769.0  1130.53  12307.47  0.0  0.0  0.0    0.0  171008.0
64        patched      1280.0  1.00   0.00  1.0  1.0  1.0  1.0    1.0          1280.0     0.00      0.00  0.0  0.0  0.0    0.0       0.0
          unpatched    1281.0  3.32  36.50  1.0  1.0  1.0  1.0  655.0          1281.0  1190.27  18687.76  0.0  0.0  0.0    0.0  334848.0
```

The test was done with a continuous resolver, using the following script (and I added some logguru logging in the `resolve_attempt_udp.cpp` source):

```dart
import 'dart:io';
import 'package:liblsl/lsl.dart';

Future<void> main() async {
  final portRange = int.parse(Platform.environment['POC_PORT_RANGE'] ?? '16');

  LSL.setConfigContent(
    LSLApiConfig(
      sessionId: 'stackpoc',
      portRange: portRange,
      ipv6: IPv6Mode.allow,
      knownPeers: const ['127.0.0.1'],
      logLevel: 0,
    ),
  );

  final info = await LSL.createStreamInfo(
    streamName: 'PocStream',
    streamType: LSLContentType.markers,
    channelCount: 1,
    sampleRate: 0,
    channelFormat: LSLChannelFormat.int32,
    sourceId: 'poc_src',
  );
  final outlet = await LSL.createOutlet(streamInfo: info);

  final resolver = LSL.createContinuousStreamResolver(
    forgetAfter: 30.0,
    maxStreams: 20,
  );
  for (var i = 0; i < 3; i++) {
    await resolver.resolve(waitTime: 2.0);
  }
  resolver.destroy();
  outlet.destroy();
  stdout.writeln('POC_OK portRange=$portRange');
}
```


[Full results table: stack.csv](https://github.com/user-attachments/files/31221843/stack.csv)
